### PR TITLE
Add and enhance fusion rectors

### DIFF
--- a/config/set/contentrepository-90.php
+++ b/config/set/contentrepository-90.php
@@ -7,6 +7,7 @@ use Neos\Rector\ContentRepository90\Rules\ContextFactoryToLegacyContextStubRecto
 use Neos\Rector\ContentRepository90\Rules\ContextGetFirstLevelNodeCacheRector;
 use Neos\Rector\ContentRepository90\Rules\ContextGetRootNodeRector;
 use Neos\Rector\ContentRepository90\Rules\FusionContextInBackendRector;
+use Neos\Rector\ContentRepository90\Rules\FusionNodePathRector;
 use Neos\Rector\ContentRepository90\Rules\InjectContentRepositoryRegistryIfNeededRector;
 use Neos\Rector\ContentRepository90\Rules\NodeFactoryResetRector;
 use Neos\Rector\ContentRepository90\Rules\NodeFindParentNodeRector;
@@ -103,7 +104,8 @@ return static function (RectorConfig $rectorConfig): void {
     $methodCallToWarningComments[] = new MethodCallToWarningComment(Node::class, 'getAccessRoles', '!! Node::getAccessRoles() is not supported by the new CR.');
     // getPath
     $rectorConfig->rule(NodeGetPathRector::class);
-        // TODO: Fusion
+    // Fusion: .depth -> Neos.NodeAccess.depth(node)
+    $rectorConfig->rule(FusionNodePathRector::class);
     // getContextPath
         // TODO: PHP
         // TODO: Fusion

--- a/config/set/contentrepository-90.php
+++ b/config/set/contentrepository-90.php
@@ -18,9 +18,11 @@ use Neos\Rector\ContentRepository90\Rules\NodeGetContextGetWorkspaceRector;
 use Neos\Rector\ContentRepository90\Rules\NodeGetDimensionsRector;
 use Neos\Rector\ContentRepository90\Rules\NodeGetPathRector;
 use Neos\Rector\ContentRepository90\Rules\NodeIsHiddenRector;
+use Neos\Rector\Generic\Rules\FusionNodePropertyPathToWarningCommentRector;
 use Neos\Rector\Generic\Rules\MethodCallToWarningCommentRector;
 use Neos\Rector\Generic\Rules\RemoveDuplicateCommentRector;
 use Neos\Rector\Generic\Rules\RemoveInjectionsRector;
+use Neos\Rector\Generic\ValueObject\FusionNodePropertyPathToWarningComment;
 use Neos\Rector\Generic\ValueObject\MethodCallToWarningComment;
 use Neos\Rector\Generic\ValueObject\RemoveInjection;
 use Rector\Config\RectorConfig;
@@ -85,19 +87,21 @@ return static function (RectorConfig $rectorConfig): void {
     // setHidden
     // isHidden
     $rectorConfig->rule(NodeIsHiddenRector::class);
+        // TODO: Fusion NodeAccess
     // setHiddenBeforeDateTime
     $methodCallToWarningComments[] = new MethodCallToWarningComment(Node::class, 'setHiddenBeforeDateTime', '!! Node::setHiddenBeforeDateTime() is not supported by the new CR. Timed publishing will be implemented not on the read model, but by dispatching commands at a given time.');
     // getHiddenBeforeDateTime
     $methodCallToWarningComments[] = new MethodCallToWarningComment(Node::class, 'getHiddenBeforeDateTime', '!! Node::getHiddenBeforeDateTime() is not supported by the new CR. Timed publishing will be implemented not on the read model, but by dispatching commands at a given time.');
-        // TODO: Fusion Warning
+    $fusionNodePropertyPathToWarningComments[] = new FusionNodePropertyPathToWarningComment('getHiddenBeforeDateTime', 'Line %LINE: !! node.getHiddenBeforeDateTime is not supported by the new CR. Timed publishing will be implemented not on the read model, but by dispatching commands at a given time.');
     // setHiddenAfterDateTime
     $methodCallToWarningComments[] = new MethodCallToWarningComment(Node::class, 'setHiddenAfterDateTime', '!! Node::setHiddenAfterDateTime() is not supported by the new CR. Timed publishing will be implemented not on the read model, but by dispatching commands at a given time.');
     // getHiddenAfterDateTime
     $methodCallToWarningComments[] = new MethodCallToWarningComment(Node::class, 'getHiddenAfterDateTime', '!! Node::getHiddenAfterDateTime() is not supported by the new CR. Timed publishing will be implemented not on the read model, but by dispatching commands at a given time.');
-        // TODO: Fusion Warning
+    $fusionNodePropertyPathToWarningComments[] = new FusionNodePropertyPathToWarningComment('getHiddenAfterDateTime', 'Line %LINE: !! node.getHiddenAfterDateTime is not supported by the new CR. Timed publishing will be implemented not on the read model, but by dispatching commands at a given time.');
     // setHiddenInIndex
     // isHiddenInIndex
-        // TODO: Fusion Warning
+        // ToDo PHP Node::properties['_isHiddenInIndex']
+        // ToDo Fusion --> node.properties._isHiddenInIndex
     // setAccessRoles
     $methodCallToWarningComments[] = new MethodCallToWarningComment(Node::class, 'setAccessRoles', '!! Node::setAccessRoles() is not supported by the new CR.');
     // getAccessRoles
@@ -139,7 +143,7 @@ return static function (RectorConfig $rectorConfig): void {
     // setRemoved()
     // isRemoved()
     $methodCallToWarningComments[] = new MethodCallToWarningComment(Node::class, 'isRemoved', '!! Node::isRemoved() - the new CR *never* returns removed nodes; so you can simplify your code and just assume removed == FALSE in all scenarios.');
-        // TODO: Fusion warning
+    $fusionNodePropertyPathToWarningComments[] = new FusionNodePropertyPathToWarningComment('isRemoved', 'Line %LINE: !! node.isRemoved - the new CR *never* returns removed nodes; so you can simplify your code and just assume removed == FALSE in all scenarios.');
     // isVisible()
     // isAccessible()
     // hasAccessRestrictions()
@@ -271,6 +275,7 @@ return static function (RectorConfig $rectorConfig): void {
      */
     $rectorConfig->ruleWithConfiguration(MethodCallToPropertyFetchRector::class, $methodCallToPropertyFetches);
     $rectorConfig->ruleWithConfiguration(MethodCallToWarningCommentRector::class, $methodCallToWarningComments);
+    $rectorConfig->ruleWithConfiguration(FusionNodePropertyPathToWarningCommentRector::class, $fusionNodePropertyPathToWarningComments);
 
     // Remove injections to classes which are gone now
     $rectorConfig->ruleWithConfiguration(RemoveInjectionsRector::class, [

--- a/src/ContentRepository90/Rules/FusionContextInBackendRector.php
+++ b/src/ContentRepository90/Rules/FusionContextInBackendRector.php
@@ -23,7 +23,7 @@ class FusionContextInBackendRector implements FusionRectorInterface
                 'Neos.Ui.NodeInfo.inBackend($1)',
                 $eelExpression
             ))
-            ->addWarningsIfRegexMatches(
+            ->addCommentsIfRegexMatches(
                 '/\.context\.inBackend/',
                 '// TODO 9.0 migration: Line %LINE: You very likely need to rewrite "VARIABLE.context.inBackend" to Neos.Ui.NodeInfo.inBackend(VARIABLE). We did not auto-apply this migration because we cannot be sure whether the variable is a Node.'
             )->getProcessedContent();

--- a/src/ContentRepository90/Rules/FusionContextLiveRector.php
+++ b/src/ContentRepository90/Rules/FusionContextLiveRector.php
@@ -23,7 +23,7 @@ class FusionContextLiveRector implements FusionRectorInterface
                 'Neos.Ui.NodeInfo.isLive($1)',
                 $eelExpression
             ))
-            ->addWarningsIfRegexMatches(
+            ->addCommentsIfRegexMatches(
                 '/\.context\.live/',
                 '// TODO 9.0 migration: Line %LINE: You very likely need to rewrite "VARIABLE.context.live" to Neos.Ui.NodeInfo.isLive(VARIABLE). We did not auto-apply this migration because we cannot be sure whether the variable is a Node.'
             )->getProcessedContent();

--- a/src/ContentRepository90/Rules/FusionNodePathRector.php
+++ b/src/ContentRepository90/Rules/FusionNodePathRector.php
@@ -25,7 +25,7 @@ class FusionNodePathRector implements FusionRectorInterface
                 'Neos.NodeAccess.path($1)',
                 $eelExpression
             ))
-            ->addWarningsIfRegexMatches(
+            ->addCommentsIfRegexMatches(
                 '/\.path$/',
                 '// TODO 9.0 migration: Line %LINE: You may need to rewrite "VARIABLE.path" to Neos.NodeAccess.path(VARIABLE). We did not auto-apply this migration because we cannot be sure whether the variable is a Node.'
             )->getProcessedContent();

--- a/src/ContentRepository90/Rules/FusionNodePathRector.php
+++ b/src/ContentRepository90/Rules/FusionNodePathRector.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\Rector\ContentRepository90\Rules;
+
+use Neos\Rector\Core\FusionProcessing\EelExpressionTransformer;
+use Neos\Rector\Core\FusionProcessing\FusionRectorInterface;
+use Neos\Rector\Utility\CodeSampleLoader;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+class FusionNodePathRector implements FusionRectorInterface
+{
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return CodeSampleLoader::fromFile('Fusion: Rewrite node.path to Neos.NodeAccess.path(node)', __CLASS__, 'some_class.fusion');
+    }
+
+    public function refactorFileContent(string $fileContent): string
+    {
+        return EelExpressionTransformer::parse($fileContent)
+            ->process(fn(string $eelExpression) => preg_replace(
+                '/(node|documentNode)\.path/',
+                'Neos.NodeAccess.path($1)',
+                $eelExpression
+            ))
+            ->addWarningsIfRegexMatches(
+                '/\.path$/',
+                '// TODO 9.0 migration: Line %LINE: You may need to rewrite "VARIABLE.path" to Neos.NodeAccess.path(VARIABLE). We did not auto-apply this migration because we cannot be sure whether the variable is a Node.'
+            )->getProcessedContent();
+    }
+}

--- a/src/ContentRepository90/Rules/FusionNodePathRector.php
+++ b/src/ContentRepository90/Rules/FusionNodePathRector.php
@@ -21,7 +21,7 @@ class FusionNodePathRector implements FusionRectorInterface
     {
         return EelExpressionTransformer::parse($fileContent)
             ->process(fn(string $eelExpression) => preg_replace(
-                '/(node|documentNode)\.path/',
+                '/(node|documentNode|site)\.path/',
                 'Neos.NodeAccess.path($1)',
                 $eelExpression
             ))

--- a/src/Core/FusionProcessing/FusionRectorInterface.php
+++ b/src/Core/FusionProcessing/FusionRectorInterface.php
@@ -8,5 +8,5 @@ use Rector\Core\Contract\Rector\RectorInterface;
 
 interface FusionRectorInterface extends RectorInterface
 {
-    public function refactorFileContent(string $getFileContent): string;
+    public function refactorFileContent(string $fileContent): string;
 }

--- a/src/Core/FusionProcessing/Helper/PrecedingFusionFileComment.php
+++ b/src/Core/FusionProcessing/Helper/PrecedingFusionFileComment.php
@@ -1,0 +1,16 @@
+<?php
+declare(strict_types=1);
+
+namespace Neos\Rector\Core\FusionProcessing\Helper;
+
+class PrecedingFusionFileComment
+{
+    public string $text = '';
+
+    public function __construct(
+        public readonly int    $lineNumberOfMatch,
+        public readonly string $template
+    )
+    {
+    }
+}

--- a/src/Core/FusionProcessing/Helper/RegexCommentTemplatePair.php
+++ b/src/Core/FusionProcessing/Helper/RegexCommentTemplatePair.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types=1);
+
+namespace Neos\Rector\Core\FusionProcessing\Helper;
+
+class RegexCommentTemplatePair
+{
+    public function __construct(
+        public readonly string $regex,
+        public readonly string $template,
+    )
+    {
+    }
+}

--- a/src/Generic/Rules/FusionNodePropertyPathToWarningCommentRector.php
+++ b/src/Generic/Rules/FusionNodePropertyPathToWarningCommentRector.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\Rector\Generic\Rules;
+
+use Neos\Rector\Core\FusionProcessing\AfxParser\AfxParserException;
+use Neos\Rector\Core\FusionProcessing\EelExpressionTransformer;
+use Neos\Rector\Core\FusionProcessing\FusionParser\Exception\ParserException;
+use Neos\Rector\Core\FusionProcessing\FusionRectorInterface;
+use Neos\Rector\Core\FusionProcessing\Helper\RegexCommentTemplatePair;
+use Neos\Rector\Generic\ValueObject\FusionNodePropertyPathToWarningComment;
+use Neos\Rector\Utility\CodeSampleLoader;
+use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use Webmozart\Assert\Assert;
+
+class FusionNodePropertyPathToWarningCommentRector implements FusionRectorInterface, ConfigurableRectorInterface
+{
+
+    use AllTraits;
+
+    /** @var FusionNodePropertyPathToWarningComment[] */
+    private array $fusionNodePropertyPathToWarningComments = [];
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return CodeSampleLoader::fromFile('Fusion: Adds a warning comment when the defined path is used within an Eel expression.', __CLASS__, 'some_class.fusion');
+    }
+
+    /**
+     * @throws ParserException
+     * @throws AfxParserException
+     */
+    public function refactorFileContent(string $fileContent): string
+    {
+
+        $regexWarningMessagePairs = [];
+        foreach ($this->fusionNodePropertyPathToWarningComments as $fusionNodePropertyPathToWarningComment) {
+
+            // escape the fusion path separator "."
+            $propertyPath = str_replace('.', '\.', $fusionNodePropertyPathToWarningComment->propertyPath);
+
+            $regexWarningMessagePairs[] = new RegexCommentTemplatePair(
+                "/(node|site|documentNode)\.$propertyPath/",
+                (string)self::todoCommentAttribute($fusionNodePropertyPathToWarningComment->warningMessage)
+            );
+
+        }
+
+        return EelExpressionTransformer::parse($fileContent)
+            ->addCommentsIfRegexesMatch($regexWarningMessagePairs)
+            ->getProcessedContent()
+        ;
+
+    }
+
+    /**
+     * @param FusionNodePropertyPathToWarningComment[] $configuration
+     */
+    public function configure(array $configuration): void
+    {
+        Assert::allIsAOf($configuration, FusionNodePropertyPathToWarningComment::class);
+        $this->fusionNodePropertyPathToWarningComments = $configuration;
+    }
+}

--- a/src/Generic/ValueObject/FusionNodePropertyPathToWarningComment.php
+++ b/src/Generic/ValueObject/FusionNodePropertyPathToWarningComment.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\Rector\Generic\ValueObject;
+
+class FusionNodePropertyPathToWarningComment
+{
+    public function __construct(
+        public readonly string $propertyPath,
+        public readonly string $warningMessage,
+    )
+    {
+    }
+}

--- a/tests/ContentRepository90/Rules/FusionNodePathRector/Fixture/some_file.fusion
+++ b/tests/ContentRepository90/Rules/FusionNodePathRector/Fixture/some_file.fusion
@@ -1,0 +1,64 @@
+prototype(Neos.Fusion.Form:Checkbox)  < prototype(Neos.Fusion.Form:Component.Field) {
+
+  renderer = Neos.Fusion:Component {
+
+    #
+    # pass down props
+    #
+    attributes = ${node.path || documentNode.path}
+
+    #
+    # the `checked` state is calculated outside the renderer to allow` overriding via `attributes`
+    #
+    checked = false
+    checked.@process.checkMultiValue = ${Array.indexOf(field.getCurrentMultivalueStringified(), field.getTargetValueStringified()) > -1}
+    checked.@process.checkMultiValue.@if.hasValue = ${field.hasCurrentValue()}
+    checked.@process.checkMultiValue.@if.isMultiple = ${field.isMultiple()}
+    checked.@process.checkSingleValue = ${field.getCurrentValueStringified() == field.getTargetValueStringified()}
+    checked.@process.checkSingleValue.@if.hasValue = ${field.hasCurrentValue()}
+    checked.@process.checkSingleValue.@if.isSingle = ${!field.isMultiple()}
+
+    renderer = afx`
+      <input
+        type="checkbox"
+        name={node.path}
+        value={someOtherVariable.path}
+        checked={props.checked}
+        {...node.path}
+      />
+    `
+  }
+}
+-----
+// TODO 9.0 migration: Line 26: You may need to rewrite "VARIABLE.path" to Neos.NodeAccess.path(VARIABLE). We did not auto-apply this migration because we cannot be sure whether the variable is a Node.
+prototype(Neos.Fusion.Form:Checkbox)  < prototype(Neos.Fusion.Form:Component.Field) {
+
+  renderer = Neos.Fusion:Component {
+
+    #
+    # pass down props
+    #
+    attributes = ${Neos.NodeAccess.path(node) || Neos.NodeAccess.path(documentNode)}
+
+    #
+    # the `checked` state is calculated outside the renderer to allow` overriding via `attributes`
+    #
+    checked = false
+    checked.@process.checkMultiValue = ${Array.indexOf(field.getCurrentMultivalueStringified(), field.getTargetValueStringified()) > -1}
+    checked.@process.checkMultiValue.@if.hasValue = ${field.hasCurrentValue()}
+    checked.@process.checkMultiValue.@if.isMultiple = ${field.isMultiple()}
+    checked.@process.checkSingleValue = ${field.getCurrentValueStringified() == field.getTargetValueStringified()}
+    checked.@process.checkSingleValue.@if.hasValue = ${field.hasCurrentValue()}
+    checked.@process.checkSingleValue.@if.isSingle = ${!field.isMultiple()}
+
+    renderer = afx`
+      <input
+        type="checkbox"
+        name={Neos.NodeAccess.path(node)}
+        value={someOtherVariable.path}
+        checked={props.checked}
+        {...Neos.NodeAccess.path(node)}
+      />
+    `
+  }
+}

--- a/tests/ContentRepository90/Rules/FusionNodePathRector/FusionNodePathRectorTest.php
+++ b/tests/ContentRepository90/Rules/FusionNodePathRector/FusionNodePathRectorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\Rector\Tests\ContentRepository90\Rules\FusionNodePathRector;
+
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class FusionNodePathRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(string $fileInfo): void
+    {
+        $this->doTestFile($fileInfo);
+    }
+
+    /**
+     * @return \Iterator<string>
+     */
+    public function provideData(): \Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture', '*.fusion');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/ContentRepository90/Rules/FusionNodePathRector/config/configured_rule.php
+++ b/tests/ContentRepository90/Rules/FusionNodePathRector/config/configured_rule.php
@@ -1,0 +1,19 @@
+<?php
+
+declare (strict_types=1);
+
+use Neos\Rector\ContentRepository90\Rules\FusionNodePathRector;
+use Neos\Rector\Core\FusionProcessing\FusionFileProcessor;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig) : void {
+    $services = $rectorConfig->services();
+    $services->defaults()
+        ->public()
+        ->autowire()
+        ->autoconfigure();
+    $services->set(FusionFileProcessor::class);
+    $rectorConfig->disableParallel(); // does not work for fusion files - see https://github.com/rectorphp/rector-src/pull/2597#issuecomment-1190120688
+
+    $rectorConfig->rule(FusionNodePathRector::class);
+};

--- a/tests/Generic/Rules/FusionNodePropertyPathToWarningCommentRector/Fixture/some_file.fusion
+++ b/tests/Generic/Rules/FusionNodePropertyPathToWarningCommentRector/Fixture/some_file.fusion
@@ -1,0 +1,105 @@
+prototype(Neos.Fusion.Form:Checkbox)  < prototype(Neos.Fusion.Form:Component.Field) {
+
+  renderer = Neos.Fusion:Component {
+
+    #
+    # pass down props
+    #
+    attributes = ${node.isRemoved || site.isRemoved || documentNode.getHiddenBeforeDateTime}
+    attributes2 = ${node.getHiddenBeforeDateTime || site.getHiddenBeforeDateTime || documentNode.isRemoved}
+    attributes3 = ${node.getHiddenAfterDateTime || site.getHiddenAfterDateTime || documentNode.getHiddenAfterDateTime}
+    attributes4 = ${node.foo.bar}
+    attributes5 = ${node.fooXbar}
+
+    #
+    # the `checked` state is calculated outside the renderer to allow` overriding via `attributes`
+    #
+    checked = false
+    checked.@process.checkMultiValue = ${Array.indexOf(field.getCurrentMultivalueStringified(), field.getTargetValueStringified()) > -1}
+    checked.@process.checkMultiValue.@if.hasValue = ${field.hasCurrentValue()}
+    checked.@process.checkMultiValue.@if.isMultiple = ${field.isMultiple()}
+    checked.@process.checkSingleValue = ${field.getCurrentValueStringified() == field.getTargetValueStringified()}
+    checked.@process.checkSingleValue.@if.hasValue = ${field.hasCurrentValue()}
+    checked.@process.checkSingleValue.@if.isSingle = ${!field.isMultiple()}
+
+    renderer = afx`
+      <input
+        type="checkbox"
+        name={node.getHiddenAfterDateTime}
+        checked={props.checked}
+        {...node.isRemoved}
+      />
+      <input
+        type="checkbox"
+        name={node.getHiddenBeforeDateTime}
+        checked={props.checked}
+        {...node.getHiddenBeforeDateTime}
+      />
+      <input
+        type="checkbox"
+        name={node.getHiddenAfterDateTime}
+        checked={props.checked}
+        {...node.isRemoved}
+      />
+    `
+  }
+}
+-----
+// TODO 9.0 migration: Line 20: !! node.isRemoved - the new CR *never* returns removed nodes; so you can simplify your code and just assume removed == FALSE in all scenarios.
+// TODO 9.0 migration: Line 21: !! node.isRemoved - the new CR *never* returns removed nodes; so you can simplify your code and just assume removed == FALSE in all scenarios.
+// TODO 9.0 migration: Line 42: !! node.isRemoved - the new CR *never* returns removed nodes; so you can simplify your code and just assume removed == FALSE in all scenarios.
+// TODO 9.0 migration: Line 54: !! node.isRemoved - the new CR *never* returns removed nodes; so you can simplify your code and just assume removed == FALSE in all scenarios.
+// TODO 9.0 migration: Line 20: !! node.getHiddenBeforeDateTime is not supported by the new CR. Timed publishing will be implemented not on the read model, but by dispatching commands at a given time.
+// TODO 9.0 migration: Line 21: !! node.getHiddenBeforeDateTime is not supported by the new CR. Timed publishing will be implemented not on the read model, but by dispatching commands at a given time.
+// TODO 9.0 migration: Line 46: !! node.getHiddenBeforeDateTime is not supported by the new CR. Timed publishing will be implemented not on the read model, but by dispatching commands at a given time.
+// TODO 9.0 migration: Line 48: !! node.getHiddenBeforeDateTime is not supported by the new CR. Timed publishing will be implemented not on the read model, but by dispatching commands at a given time.
+// TODO 9.0 migration: Line 22: !! node.getHiddenAfterDateTime is not supported by the new CR. Timed publishing will be implemented not on the read model, but by dispatching commands at a given time.
+// TODO 9.0 migration: Line 40: !! node.getHiddenAfterDateTime is not supported by the new CR. Timed publishing will be implemented not on the read model, but by dispatching commands at a given time.
+// TODO 9.0 migration: Line 52: !! node.getHiddenAfterDateTime is not supported by the new CR. Timed publishing will be implemented not on the read model, but by dispatching commands at a given time.
+// TODO 9.0 migration: Line 23: !! node.foo.bar is not supported anymore.
+prototype(Neos.Fusion.Form:Checkbox)  < prototype(Neos.Fusion.Form:Component.Field) {
+
+  renderer = Neos.Fusion:Component {
+
+    #
+    # pass down props
+    #
+    attributes = ${node.isRemoved || site.isRemoved || documentNode.getHiddenBeforeDateTime}
+    attributes2 = ${node.getHiddenBeforeDateTime || site.getHiddenBeforeDateTime || documentNode.isRemoved}
+    attributes3 = ${node.getHiddenAfterDateTime || site.getHiddenAfterDateTime || documentNode.getHiddenAfterDateTime}
+    attributes4 = ${node.foo.bar}
+    attributes5 = ${node.fooXbar}
+
+    #
+    # the `checked` state is calculated outside the renderer to allow` overriding via `attributes`
+    #
+    checked = false
+    checked.@process.checkMultiValue = ${Array.indexOf(field.getCurrentMultivalueStringified(), field.getTargetValueStringified()) > -1}
+    checked.@process.checkMultiValue.@if.hasValue = ${field.hasCurrentValue()}
+    checked.@process.checkMultiValue.@if.isMultiple = ${field.isMultiple()}
+    checked.@process.checkSingleValue = ${field.getCurrentValueStringified() == field.getTargetValueStringified()}
+    checked.@process.checkSingleValue.@if.hasValue = ${field.hasCurrentValue()}
+    checked.@process.checkSingleValue.@if.isSingle = ${!field.isMultiple()}
+
+    renderer = afx`
+      <input
+        type="checkbox"
+        name={node.getHiddenAfterDateTime}
+        checked={props.checked}
+        {...node.isRemoved}
+      />
+      <input
+        type="checkbox"
+        name={node.getHiddenBeforeDateTime}
+        checked={props.checked}
+        {...node.getHiddenBeforeDateTime}
+      />
+      <input
+        type="checkbox"
+        name={node.getHiddenAfterDateTime}
+        checked={props.checked}
+        {...node.isRemoved}
+      />
+    `
+  }
+}

--- a/tests/Generic/Rules/FusionNodePropertyPathToWarningCommentRector/FusionNodePropertyPathToWarningCommentRectorTest.php
+++ b/tests/Generic/Rules/FusionNodePropertyPathToWarningCommentRector/FusionNodePropertyPathToWarningCommentRectorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\Rector\Tests\Generic\Rules\FusionNodePropertyPathToWarningCommentRector;
+
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class FusionNodePropertyPathToWarningCommentRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(string $fileInfo): void
+    {
+        $this->doTestFile($fileInfo);
+    }
+
+    /**
+     * @return \Iterator<string>
+     */
+    public function provideData(): \Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture', '*.fusion');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Generic/Rules/FusionNodePropertyPathToWarningCommentRector/config/configured_rule.php
+++ b/tests/Generic/Rules/FusionNodePropertyPathToWarningCommentRector/config/configured_rule.php
@@ -1,0 +1,25 @@
+<?php
+
+declare (strict_types=1);
+
+use Neos\Rector\Core\FusionProcessing\FusionFileProcessor;
+use Neos\Rector\Generic\Rules\FusionNodePropertyPathToWarningCommentRector;
+use Neos\Rector\Generic\ValueObject\FusionNodePropertyPathToWarningComment;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig) : void {
+    $services = $rectorConfig->services();
+    $services->defaults()
+        ->public()
+        ->autowire()
+        ->autoconfigure();
+    $services->set(FusionFileProcessor::class);
+    $rectorConfig->disableParallel(); // does not work for fusion files - see https://github.com/rectorphp/rector-src/pull/2597#issuecomment-1190120688
+
+    $rectorConfig->ruleWithConfiguration(FusionNodePropertyPathToWarningCommentRector::class, [
+        new FusionNodePropertyPathToWarningComment('isRemoved', 'Line %LINE: !! node.isRemoved - the new CR *never* returns removed nodes; so you can simplify your code and just assume removed == FALSE in all scenarios.'),
+        new FusionNodePropertyPathToWarningComment('getHiddenBeforeDateTime', 'Line %LINE: !! node.getHiddenBeforeDateTime is not supported by the new CR. Timed publishing will be implemented not on the read model, but by dispatching commands at a given time.'),
+        new FusionNodePropertyPathToWarningComment('getHiddenAfterDateTime', 'Line %LINE: !! node.getHiddenAfterDateTime is not supported by the new CR. Timed publishing will be implemented not on the read model, but by dispatching commands at a given time.'),
+        new FusionNodePropertyPathToWarningComment('foo.bar', 'Line %LINE: !! node.foo.bar is not supported anymore.'),
+    ]);
+};


### PR DESCRIPTION
Add FusionNodePathRector to transform 
`node.path`
to
`Neos.NodeInfo.path(node)`

Enhance EelExpressionTransformer to add multiple comments by multiple regular expression matches with correct line number references.

Add FusionNodePropertyPathToWarningCommentRector to add comments for
`node.foo` or `node.bar.baz`
when there is no automatic migration available.