### PR TITLE
TASK: replace `Neos.Ui.NodeInfo.inBackend` and `Neos.Ui.NodeInfo.isLive` with correct eel helper

### DIFF
--- a/config/set/contentrepository-90.php
+++ b/config/set/contentrepository-90.php
@@ -258,10 +258,10 @@ return static function (RectorConfig $rectorConfig): void {
     // ContentContext::getCurrentSiteNode
     // TODO: PHP
     // TODO: Fusion
-    // ContentContext::isLive -> Neos.Ui.NodeInfo.isLive(...) (TODO - should this be part of Neos.Ui or Neos Namespace?)
+    // ContentContext::isLive -> Neos.Node.isLive(...)
     // TODO: PHP
     $rectorConfig->rule(FusionContextLiveRector::class);
-    // ContentContext::isInBackend -> Neos.Ui.NodeInfo.inBackend(...) (TODO - should this be part of Neos.Ui or Neos Namespace?)
+    // ContentContext::isInBackend -> Neos.Node.inBackend(...)
     // TODO: PHP
     $rectorConfig->rule(FusionContextInBackendRector::class);
     // ContentContext::getCurrentRenderingMode

--- a/docs/architecture_2022_09_16_FusionRefactorings.md
+++ b/docs/architecture_2022_09_16_FusionRefactorings.md
@@ -3,7 +3,7 @@
 ## Problem Description
 
 We want to refactor Eel expressions like `node.context.inBackend` or `site.context.inBackend` towards
-`Neos.Ui.NodeInfo.inBackend(node)` and `Neos.Ui.NodeInfo.inBackend(site)` respectively.
+`Neos.Node.inBackend(node)` and `Neos.Node.inBackend(site)` respectively.
 
 This must work BOTH in Eel expressions inside Fusion, and inside AFX blocks.
 

--- a/src/ContentRepository90/Rules/FusionContextInBackendRector.php
+++ b/src/ContentRepository90/Rules/FusionContextInBackendRector.php
@@ -12,7 +12,7 @@ class FusionContextInBackendRector implements FusionRectorInterface
 
     public function getRuleDefinition(): RuleDefinition
     {
-        return CodeSampleLoader::fromFile('Fusion: Rewrite node.context.inBackend to Neos.Ui.NodeInfo.inBackend(...)', __CLASS__, 'some_class.fusion');
+        return CodeSampleLoader::fromFile('Fusion: Rewrite node.context.inBackend to Neos.Node.inBackend(...)', __CLASS__, 'some_class.fusion');
     }
 
     public function refactorFileContent(string $fileContent): string
@@ -20,12 +20,12 @@ class FusionContextInBackendRector implements FusionRectorInterface
         return EelExpressionTransformer::parse($fileContent)
             ->process(fn(string $eelExpression) => preg_replace(
                 '/(node|documentNode|site)\.context\.inBackend/',
-                'Neos.Ui.NodeInfo.inBackend($1)',
+                'Neos.Node.inBackend($1)',
                 $eelExpression
             ))
             ->addCommentsIfRegexMatches(
                 '/\.context\.inBackend/',
-                '// TODO 9.0 migration: Line %LINE: You very likely need to rewrite "VARIABLE.context.inBackend" to Neos.Ui.NodeInfo.inBackend(VARIABLE). We did not auto-apply this migration because we cannot be sure whether the variable is a Node.'
+                '// TODO 9.0 migration: Line %LINE: You very likely need to rewrite "VARIABLE.context.inBackend" to Neos.Node.inBackend(VARIABLE). We did not auto-apply this migration because we cannot be sure whether the variable is a Node.'
             )->getProcessedContent();
     }
 }

--- a/src/ContentRepository90/Rules/FusionContextLiveRector.php
+++ b/src/ContentRepository90/Rules/FusionContextLiveRector.php
@@ -12,7 +12,7 @@ class FusionContextLiveRector implements FusionRectorInterface
 
     public function getRuleDefinition(): RuleDefinition
     {
-        return CodeSampleLoader::fromFile('Fusion: Rewrite node.context.live to Neos.Ui.NodeInfo.isLive(...)', __CLASS__, 'some_class.fusion');
+        return CodeSampleLoader::fromFile('Fusion: Rewrite node.context.live to Neos.Node.isLive(...)', __CLASS__, 'some_class.fusion');
     }
 
     public function refactorFileContent(string $fileContent): string
@@ -20,12 +20,12 @@ class FusionContextLiveRector implements FusionRectorInterface
         return EelExpressionTransformer::parse($fileContent)
             ->process(fn(string $eelExpression) => preg_replace(
                 '/(node|documentNode|site)\.context\.live/',
-                'Neos.Ui.NodeInfo.isLive($1)',
+                'Neos.Node.isLive($1)',
                 $eelExpression
             ))
             ->addCommentsIfRegexMatches(
                 '/\.context\.live/',
-                '// TODO 9.0 migration: Line %LINE: You very likely need to rewrite "VARIABLE.context.live" to Neos.Ui.NodeInfo.isLive(VARIABLE). We did not auto-apply this migration because we cannot be sure whether the variable is a Node.'
+                '// TODO 9.0 migration: Line %LINE: You very likely need to rewrite "VARIABLE.context.live" to Neos.Node.isLive(VARIABLE). We did not auto-apply this migration because we cannot be sure whether the variable is a Node.'
             )->getProcessedContent();
     }
 }

--- a/tests/ContentRepository90/Rules/FusionContextInBackendRector/Fixture/some_file.fusion
+++ b/tests/ContentRepository90/Rules/FusionContextInBackendRector/Fixture/some_file.fusion
@@ -30,7 +30,7 @@ prototype(Neos.Fusion.Form:Checkbox)  < prototype(Neos.Fusion.Form:Component.Fie
   }
 }
 -----
-// TODO 9.0 migration: Line 26: You very likely need to rewrite "VARIABLE.context.inBackend" to Neos.Ui.NodeInfo.inBackend(VARIABLE). We did not auto-apply this migration because we cannot be sure whether the variable is a Node.
+// TODO 9.0 migration: Line 26: You very likely need to rewrite "VARIABLE.context.inBackend" to Neos.Node.inBackend(VARIABLE). We did not auto-apply this migration because we cannot be sure whether the variable is a Node.
 prototype(Neos.Fusion.Form:Checkbox)  < prototype(Neos.Fusion.Form:Component.Field) {
 
   renderer = Neos.Fusion:Component {
@@ -38,7 +38,7 @@ prototype(Neos.Fusion.Form:Checkbox)  < prototype(Neos.Fusion.Form:Component.Fie
     #
     # pass down props
     #
-    attributes = ${Neos.Ui.NodeInfo.inBackend(node) || Neos.Ui.NodeInfo.inBackend(site) || Neos.Ui.NodeInfo.inBackend(documentNode)}
+    attributes = ${Neos.Node.inBackend(node) || Neos.Node.inBackend(site) || Neos.Node.inBackend(documentNode)}
 
     #
     # the `checked` state is calculated outside the renderer to allow` overriding via `attributes`
@@ -54,10 +54,10 @@ prototype(Neos.Fusion.Form:Checkbox)  < prototype(Neos.Fusion.Form:Component.Fie
     renderer = afx`
       <input
         type="checkbox"
-        name={Neos.Ui.NodeInfo.inBackend(node)}
+        name={Neos.Node.inBackend(node)}
         value={someOtherVariable.context.inBackend}
         checked={props.checked}
-        {...Neos.Ui.NodeInfo.inBackend(node)}
+        {...Neos.Node.inBackend(node)}
       />
     `
   }

--- a/tests/ContentRepository90/Rules/FusionContextLiveRector/Fixture/some_file.fusion
+++ b/tests/ContentRepository90/Rules/FusionContextLiveRector/Fixture/some_file.fusion
@@ -30,7 +30,7 @@ prototype(Neos.Fusion.Form:Checkbox)  < prototype(Neos.Fusion.Form:Component.Fie
   }
 }
 -----
-// TODO 9.0 migration: Line 26: You very likely need to rewrite "VARIABLE.context.live" to Neos.Ui.NodeInfo.isLive(VARIABLE). We did not auto-apply this migration because we cannot be sure whether the variable is a Node.
+// TODO 9.0 migration: Line 26: You very likely need to rewrite "VARIABLE.context.live" to Neos.Node.isLive(VARIABLE). We did not auto-apply this migration because we cannot be sure whether the variable is a Node.
 prototype(Neos.Fusion.Form:Checkbox)  < prototype(Neos.Fusion.Form:Component.Field) {
 
   renderer = Neos.Fusion:Component {
@@ -38,7 +38,7 @@ prototype(Neos.Fusion.Form:Checkbox)  < prototype(Neos.Fusion.Form:Component.Fie
     #
     # pass down props
     #
-    attributes = ${Neos.Ui.NodeInfo.isLive(node) || Neos.Ui.NodeInfo.isLive(site) || Neos.Ui.NodeInfo.isLive(documentNode)}
+    attributes = ${Neos.Node.isLive(node) || Neos.Node.isLive(site) || Neos.Node.isLive(documentNode)}
 
     #
     # the `checked` state is calculated outside the renderer to allow` overriding via `attributes`
@@ -54,10 +54,10 @@ prototype(Neos.Fusion.Form:Checkbox)  < prototype(Neos.Fusion.Form:Component.Fie
     renderer = afx`
       <input
         type="checkbox"
-        name={Neos.Ui.NodeInfo.isLive(node)}
+        name={Neos.Node.isLive(node)}
         value={someOtherVariable.context.live}
         checked={props.checked}
-        {...Neos.Ui.NodeInfo.isLive(node)}
+        {...Neos.Node.isLive(node)}
       />
     `
   }


### PR DESCRIPTION
- Replace all usages of `Neos.Ui.NodeInfo.inBackend` in favour of `Neos.Node.inBackend`
- Replace all usages of `Neos.Ui.NodeInfo.isLive` in favour of `Neos.Node.isLive`

Relates: neos/neos-development-collection#4074
Relates: neos/neos-ui#3414