### PR TITLE
TASK: Adjust migration for user interface mode

### DIFF
--- a/src/ContentRepository90/Rules/FusionContextInBackendRector.php
+++ b/src/ContentRepository90/Rules/FusionContextInBackendRector.php
@@ -20,12 +20,12 @@ class FusionContextInBackendRector implements FusionRectorInterface
         return EelExpressionTransformer::parse($fileContent)
             ->process(fn(string $eelExpression) => preg_replace(
                 '/(node|documentNode|site)\.context\.inBackend/',
-                'Neos.Node.inBackend($1)',
+                'renderingMode.isEdit',
                 $eelExpression
             ))
             ->addCommentsIfRegexMatches(
                 '/\.context\.inBackend/',
-                '// TODO 9.0 migration: Line %LINE: You very likely need to rewrite "VARIABLE.context.inBackend" to Neos.Node.inBackend(VARIABLE). We did not auto-apply this migration because we cannot be sure whether the variable is a Node.'
+                '// TODO 9.0 migration: Line %LINE: You very likely need to rewrite "VARIABLE.context.inBackend" to "renderingMode.isEdit". We did not auto-apply this migration because we cannot be sure whether the variable is a Node.'
             )->getProcessedContent();
     }
 }

--- a/src/ContentRepository90/Rules/FusionContextLiveRector.php
+++ b/src/ContentRepository90/Rules/FusionContextLiveRector.php
@@ -20,12 +20,12 @@ class FusionContextLiveRector implements FusionRectorInterface
         return EelExpressionTransformer::parse($fileContent)
             ->process(fn(string $eelExpression) => preg_replace(
                 '/(node|documentNode|site)\.context\.live/',
-                'Neos.Node.isLive($1)',
+                '!renderingMode.isEdit',
                 $eelExpression
             ))
             ->addCommentsIfRegexMatches(
                 '/\.context\.live/',
-                '// TODO 9.0 migration: Line %LINE: You very likely need to rewrite "VARIABLE.context.live" to Neos.Node.isLive(VARIABLE). We did not auto-apply this migration because we cannot be sure whether the variable is a Node.'
+                '// TODO 9.0 migration: Line %LINE: You very likely need to rewrite "VARIABLE.context.live" to "!renderingMode.isEdit". We did not auto-apply this migration because we cannot be sure whether the variable is a Node.'
             )->getProcessedContent();
     }
 }

--- a/tests/ContentRepository90/Rules/FusionContextInBackendRector/Fixture/some_file.fusion.inc
+++ b/tests/ContentRepository90/Rules/FusionContextInBackendRector/Fixture/some_file.fusion.inc
@@ -30,7 +30,7 @@ prototype(Neos.Fusion.Form:Checkbox)  < prototype(Neos.Fusion.Form:Component.Fie
   }
 }
 -----
-// TODO 9.0 migration: Line 26: You very likely need to rewrite "VARIABLE.context.inBackend" to Neos.Node.inBackend(VARIABLE). We did not auto-apply this migration because we cannot be sure whether the variable is a Node.
+// TODO 9.0 migration: Line 26: You very likely need to rewrite "VARIABLE.context.inBackend" to "renderingMode.isEdit". We did not auto-apply this migration because we cannot be sure whether the variable is a Node.
 prototype(Neos.Fusion.Form:Checkbox)  < prototype(Neos.Fusion.Form:Component.Field) {
 
   renderer = Neos.Fusion:Component {
@@ -38,7 +38,7 @@ prototype(Neos.Fusion.Form:Checkbox)  < prototype(Neos.Fusion.Form:Component.Fie
     #
     # pass down props
     #
-    attributes = ${Neos.Node.inBackend(node) || Neos.Node.inBackend(site) || Neos.Node.inBackend(documentNode)}
+    attributes = ${renderingMode.isEdit || renderingMode.isEdit || renderingMode.isEdit}
 
     #
     # the `checked` state is calculated outside the renderer to allow` overriding via `attributes`
@@ -54,10 +54,10 @@ prototype(Neos.Fusion.Form:Checkbox)  < prototype(Neos.Fusion.Form:Component.Fie
     renderer = afx`
       <input
         type="checkbox"
-        name={Neos.Node.inBackend(node)}
+        name={renderingMode.isEdit}
         value={someOtherVariable.context.inBackend}
         checked={props.checked}
-        {...Neos.Node.inBackend(node)}
+        {...renderingMode.isEdit}
       />
     `
   }

--- a/tests/ContentRepository90/Rules/FusionContextLiveRector/Fixture/some_file.fusion.inc
+++ b/tests/ContentRepository90/Rules/FusionContextLiveRector/Fixture/some_file.fusion.inc
@@ -30,7 +30,7 @@ prototype(Neos.Fusion.Form:Checkbox)  < prototype(Neos.Fusion.Form:Component.Fie
   }
 }
 -----
-// TODO 9.0 migration: Line 26: You very likely need to rewrite "VARIABLE.context.live" to Neos.Node.isLive(VARIABLE). We did not auto-apply this migration because we cannot be sure whether the variable is a Node.
+// TODO 9.0 migration: Line 26: You very likely need to rewrite "VARIABLE.context.live" to "!renderingMode.isEdit". We did not auto-apply this migration because we cannot be sure whether the variable is a Node.
 prototype(Neos.Fusion.Form:Checkbox)  < prototype(Neos.Fusion.Form:Component.Field) {
 
   renderer = Neos.Fusion:Component {
@@ -38,7 +38,7 @@ prototype(Neos.Fusion.Form:Checkbox)  < prototype(Neos.Fusion.Form:Component.Fie
     #
     # pass down props
     #
-    attributes = ${Neos.Node.isLive(node) || Neos.Node.isLive(site) || Neos.Node.isLive(documentNode)}
+    attributes = ${!renderingMode.isEdit || !renderingMode.isEdit || !renderingMode.isEdit}
 
     #
     # the `checked` state is calculated outside the renderer to allow` overriding via `attributes`
@@ -54,10 +54,10 @@ prototype(Neos.Fusion.Form:Checkbox)  < prototype(Neos.Fusion.Form:Component.Fie
     renderer = afx`
       <input
         type="checkbox"
-        name={Neos.Node.isLive(node)}
+        name={!renderingMode.isEdit}
         value={someOtherVariable.context.live}
         checked={props.checked}
-        {...Neos.Node.isLive(node)}
+        {...!renderingMode.isEdit}
       />
     `
   }


### PR DESCRIPTION
the migration previously adjusted the code to a now deprecated eel helper. In pr https://github.com/neos/neos-development-collection/pull/4505 the userInterfaceMode is introduced as global fusionValue which made an adjustment in the rector necessary.

`(node|documentNode|site).context.inBackend` is now migrated to `userInterfaceMode.isEdit` `(node|documentNode|site).context.live` is now migrated to `userInterfaceMode.isLive`

In cases where it cannot be determined wether a node is affected by the `context` operation a comment is added as before.

Relates: https://github.com/neos/neos-development-collection/issues/4086