### PR TITLE
FEATURE: Rewrite NodeType::getName()

### DIFF
--- a/config/set/contentrepository-90.php
+++ b/config/set/contentrepository-90.php
@@ -45,6 +45,8 @@ use Rector\Transform\Rector\MethodCall\MethodCallToPropertyFetchRector;
 use Rector\Transform\ValueObject\MethodCallToPropertyFetch;
 use Neos\Rector\ContentRepository90\Rules\WorkspaceGetNameRector;
 use Neos\Rector\ContentRepository90\Rules\NodeGetIdentifierRector;
+use Neos\Rector\ContentRepository90\Rules\FusionNodeTypeNameRector;
+use Neos\Rector\ContentRepository90\Rules\NodeTypeGetNameRector;
 
 return static function (RectorConfig $rectorConfig): void {
     // Register FusionFileProcessor. All Fusion Rectors will be auto-registered at this processor.
@@ -214,6 +216,13 @@ return static function (RectorConfig $rectorConfig): void {
     // getProperty() ** (included/compatible in old NodeInterface)
     // hasProperty() ** (included/compatible in old NodeInterface)
     // getLabel() ** (included/compatible in old NodeInterface)
+
+    /**
+     * Neos\ContentRepository\Core\NodeType\NodeType
+     */
+    // getName()
+    $rectorConfig->rule(rectorClass: FusionNodeTypeNameRector::class);
+    $rectorConfig->rule(rectorClass: NodeTypeGetNameRector::class);
 
     /**
      * Neos\ContentRepository\Domain\Projection\Content\TraversableNodeInterface

--- a/src/ContentRepository90/Rules/FusionNodeTypeNameRector.php
+++ b/src/ContentRepository90/Rules/FusionNodeTypeNameRector.php
@@ -27,7 +27,7 @@ class FusionNodeTypeNameRector implements FusionRectorInterface
             ))
             ->addCommentsIfRegexMatches(
                 '/\.nodeType.name/',
-                '// TODO 9.0 migration: Line %LINE: You may need to rewrite "VARIABLE.nodeType.name" to VARIABLE.nodeTypeName.value. We did not auto-apply this migration because we cannot be sure whether the variable is a Node.'
+                '// TODO 9.0 migration: Line %LINE: You may need to rewrite "VARIABLE.nodeType.name" to "VARIABLE.nodeTypeName.value". We did not auto-apply this migration because we cannot be sure whether the variable is a Node.'
             )->getProcessedContent();
     }
 }

--- a/src/ContentRepository90/Rules/FusionNodeTypeNameRector.php
+++ b/src/ContentRepository90/Rules/FusionNodeTypeNameRector.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\Rector\ContentRepository90\Rules;
+
+use Neos\Rector\Core\FusionProcessing\EelExpressionTransformer;
+use Neos\Rector\Core\FusionProcessing\FusionRectorInterface;
+use Neos\Rector\Utility\CodeSampleLoader;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+class FusionNodeTypeNameRector implements FusionRectorInterface
+{
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return CodeSampleLoader::fromFile('Fusion: Rewrite node.nodeType.name to node.nodeTypeName.value', __CLASS__);
+    }
+
+    public function refactorFileContent(string $fileContent): string
+    {
+        return EelExpressionTransformer::parse($fileContent)
+            ->process(fn(string $eelExpression) => preg_replace(
+                '/(node|documentNode|site)\.nodeType\.name/',
+                '$1.nodeTypeName.value',
+                $eelExpression
+            ))
+            ->addCommentsIfRegexMatches(
+                '/\.nodeType.name/',
+                '// TODO 9.0 migration: Line %LINE: You may need to rewrite "VARIABLE.nodeType.name" to VARIABLE.nodeTypeName.value. We did not auto-apply this migration because we cannot be sure whether the variable is a Node.'
+            )->getProcessedContent();
+    }
+}

--- a/src/ContentRepository90/Rules/NodeTypeGetNameRector.php
+++ b/src/ContentRepository90/Rules/NodeTypeGetNameRector.php
@@ -1,0 +1,53 @@
+<?php
+
+declare (strict_types=1);
+
+namespace Neos\Rector\ContentRepository90\Rules;
+
+use Neos\Rector\Utility\CodeSampleLoader;
+use PhpParser\Node;
+use PHPStan\Type\ObjectType;
+use Rector\Core\Rector\AbstractRector;
+use Rector\PostRector\Collector\NodesToAddCollector;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+final class NodeTypeGetNameRector extends AbstractRector
+{
+    use AllTraits;
+
+    public function __construct(
+        private readonly NodesToAddCollector $nodesToAddCollector
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return CodeSampleLoader::fromFile('"NodeInterface::getChildNodes()" will be rewritten', __CLASS__);
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [\PhpParser\Node\Expr\MethodCall::class];
+    }
+
+    /**
+     * @param \PhpParser\Node\Expr\MethodCall $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        assert($node instanceof Node\Expr\MethodCall);
+
+        if (!$this->isObjectType($node->var, new ObjectType('Neos\ContentRepository\Core\NodeType\NodeType'))) {
+            return null;
+        }
+        if (!$this->isName($node->name, 'getName')) {
+            return null;
+        }
+
+        $propertyFetchAggregateId = $this->nodeFactory->createPropertyFetch($node->var, 'name');
+        return $this->nodeFactory->createPropertyFetch($propertyFetchAggregateId, 'value');
+    }
+}

--- a/src/ContentRepository90/Rules/NodeTypeGetNameRector.php
+++ b/src/ContentRepository90/Rules/NodeTypeGetNameRector.php
@@ -22,7 +22,7 @@ final class NodeTypeGetNameRector extends AbstractRector
 
     public function getRuleDefinition(): RuleDefinition
     {
-        return CodeSampleLoader::fromFile('"NodeInterface::getChildNodes()" will be rewritten', __CLASS__);
+        return CodeSampleLoader::fromFile('"NodeType::getName()" will be rewritten', __CLASS__);
     }
 
     /**

--- a/tests/ContentRepository90/Rules/FusionNodeTypeNameRector/Fixture/some_file.fusion.inc
+++ b/tests/ContentRepository90/Rules/FusionNodeTypeNameRector/Fixture/some_file.fusion.inc
@@ -1,0 +1,36 @@
+prototype(Neos.Fusion.Form:Checkbox)  < prototype(Neos.Fusion.Form:Component.Field) {
+
+renderer = Neos.Fusion:Component {
+
+#
+# pass down props
+#
+attributes = ${node.nodeType.name || documentNode.nodeType.name}
+renderer = afx`
+<input
+        name={node.nodeType.name}
+        value={someOtherVariable.nodeType.name}
+        {...node.nodeType.name}
+/>
+`
+}
+}
+-----
+// TODO 9.0 migration: Line 13: You may need to rewrite "VARIABLE.nodeType.name" to VARIABLE.nodeTypeName.value. We did not auto-apply this migration because we cannot be sure whether the variable is a Node.
+prototype(Neos.Fusion.Form:Checkbox)  < prototype(Neos.Fusion.Form:Component.Field) {
+
+renderer = Neos.Fusion:Component {
+
+#
+# pass down props
+#
+attributes = ${node.nodeTypeName.value || documentNode.nodeTypeName.value}
+renderer = afx`
+<input
+        name={node.nodeTypeName.value}
+        value={someOtherVariable.nodeType.name}
+        {...node.nodeTypeName.value}
+/>
+`
+}
+}

--- a/tests/ContentRepository90/Rules/FusionNodeTypeNameRector/Fixture/some_file.fusion.inc
+++ b/tests/ContentRepository90/Rules/FusionNodeTypeNameRector/Fixture/some_file.fusion.inc
@@ -16,7 +16,7 @@ renderer = afx`
 }
 }
 -----
-// TODO 9.0 migration: Line 13: You may need to rewrite "VARIABLE.nodeType.name" to VARIABLE.nodeTypeName.value. We did not auto-apply this migration because we cannot be sure whether the variable is a Node.
+// TODO 9.0 migration: Line 13: You may need to rewrite "VARIABLE.nodeType.name" to "VARIABLE.nodeTypeName.value". We did not auto-apply this migration because we cannot be sure whether the variable is a Node.
 prototype(Neos.Fusion.Form:Checkbox)  < prototype(Neos.Fusion.Form:Component.Field) {
 
 renderer = Neos.Fusion:Component {

--- a/tests/ContentRepository90/Rules/FusionNodeTypeNameRector/FusionNodeTypeNameRectorTest.php
+++ b/tests/ContentRepository90/Rules/FusionNodeTypeNameRector/FusionNodeTypeNameRectorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\Rector\Tests\ContentRepository90\Rules\FusionNodePathRector;
+
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class FusionNodeTypeNameRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(string $fileInfo): void
+    {
+        $this->doTestFile($fileInfo);
+    }
+
+    /**
+     * @return \Iterator<string>
+     */
+    public function provideData(): \Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture', '*.fusion.inc');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/ContentRepository90/Rules/FusionNodeTypeNameRector/config/configured_rule.php
+++ b/tests/ContentRepository90/Rules/FusionNodeTypeNameRector/config/configured_rule.php
@@ -1,0 +1,19 @@
+<?php
+
+declare (strict_types=1);
+
+use Neos\Rector\ContentRepository90\Rules\FusionNodeTypeNameRector;
+use Neos\Rector\Core\FusionProcessing\FusionFileProcessor;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    $services = $rectorConfig->services();
+    $services->defaults()
+        ->public()
+        ->autowire()
+        ->autoconfigure();
+    $services->set(FusionFileProcessor::class);
+    $rectorConfig->disableParallel(); // does not work for fusion files - see https://github.com/rectorphp/rector-src/pull/2597#issuecomment-1190120688
+
+    $rectorConfig->rule(FusionNodeTypeNameRector::class);
+};

--- a/tests/Rules/NodeTypeGetNameRector/Fixture/all.php.inc
+++ b/tests/Rules/NodeTypeGetNameRector/Fixture/all.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+use Neos\ContentRepository\Core\NodeType\NodeType;
+
+class SomeClass
+{
+    public function run(NodeType $nodetype)
+    {
+        $nodetype = $nodetype->getName();
+    }
+}
+
+?>
+-----
+<?php
+
+use Neos\ContentRepository\Core\NodeType\NodeType;
+
+class SomeClass
+{
+    public function run(NodeType $nodetype)
+    {
+        $nodetype = $nodetype->name->value;
+    }
+}
+
+?>

--- a/tests/Rules/NodeTypeGetNameRector/NodeTypeGetNameRectorTest.php
+++ b/tests/Rules/NodeTypeGetNameRector/NodeTypeGetNameRectorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\Rector\Tests\Rules\NodeTypeGetNameRector;
+
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class NodeTypeGetNameRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(string $fileInfo): void
+    {
+        $this->doTestFile($fileInfo);
+    }
+
+    /**
+     * @return \Iterator<string>
+     */
+    public function provideData(): \Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Rules/NodeTypeGetNameRector/config/configured_rule.php
+++ b/tests/Rules/NodeTypeGetNameRector/config/configured_rule.php
@@ -1,0 +1,11 @@
+<?php
+
+declare (strict_types=1);
+//namespace RectorPrefix202208;
+
+use Neos\Rector\ContentRepository90\Rules\NodeTypeGetNameRector;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig) : void {
+    $rectorConfig->rule(NodeTypeGetNameRector::class);
+};


### PR DESCRIPTION
Rector migration for `NodeType::getName` removal

https://github.com/neos/neos-development-collection/issues/4560

**PHP**
`$nodeType->getName()` to `$nodeType->name->value`

**Fusion**
`${node.nodeType.name}` to `${node.nodeTypeName.value}`

Fixes partly #25