### PR TITLE
TASK: Migrate fusion `context.currentRenderingMode` statements

### DIFF
--- a/config/set/contentrepository-90.php
+++ b/config/set/contentrepository-90.php
@@ -7,6 +7,7 @@ use Neos\Rector\ContentRepository90\Rules\ContextFactoryToLegacyContextStubRecto
 use Neos\Rector\ContentRepository90\Rules\ContextGetFirstLevelNodeCacheRector;
 use Neos\Rector\ContentRepository90\Rules\ContextGetRootNodeRector;
 use Neos\Rector\ContentRepository90\Rules\FusionCachingNodeInEntryIdentifierRector;
+use Neos\Rector\ContentRepository90\Rules\FusionContextCurrentRenderingModeRector;
 use Neos\Rector\ContentRepository90\Rules\FusionContextCurrentSiteRector;
 use Neos\Rector\ContentRepository90\Rules\FusionContextInBackendRector;
 use Neos\Rector\ContentRepository90\Rules\FusionContextLiveRector;
@@ -281,15 +282,16 @@ return static function (RectorConfig $rectorConfig): void {
     // ContentContext::getCurrentSiteNode
     // TODO: PHP
     // TODO: Fusion
-    // ContentContext::isLive -> Neos.Node.isLive(...)
+    // ContentContext::isLive -> renderingMode.isLive
     // TODO: PHP
     $rectorConfig->rule(FusionContextLiveRector::class);
-    // ContentContext::isInBackend -> Neos.Node.inBackend(...)
+    // ContentContext::isInBackend -> renderingMode.inBackend
     // TODO: PHP
     $rectorConfig->rule(FusionContextInBackendRector::class);
-    // ContentContext::getCurrentRenderingMode
+    // ContentContext::getCurrentRenderingMode... -> renderingMode...
     // TODO: PHP
-    // TODO: Fusion
+    $rectorConfig->rule(FusionContextCurrentRenderingModeRector::class);
+
 
     /**
      * ContentDimensionCombinator

--- a/src/ContentRepository90/Rules/FusionContextCurrentRenderingModeRector.php
+++ b/src/ContentRepository90/Rules/FusionContextCurrentRenderingModeRector.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Neos\Rector\ContentRepository90\Rules;
+
+use Neos\Rector\Core\FusionProcessing\EelExpressionTransformer;
+use Neos\Rector\Core\FusionProcessing\FusionRectorInterface;
+use Neos\Rector\Utility\CodeSampleLoader;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+class FusionContextCurrentRenderingModeRector implements FusionRectorInterface
+{
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return CodeSampleLoader::fromFile('Fusion: Rewrite node.context.currentRenderingMode... to renderingMode...', __CLASS__);
+    }
+
+    public function refactorFileContent(string $fileContent): string
+    {
+        return EelExpressionTransformer::parse($fileContent)
+            ->process(fn(string $eelExpression) => preg_replace(
+                '/(node|documentNode|site)\.context\.currentRenderingMode\.(name|title|fusionPath|options)/',
+                'renderingMode.$2',
+                $eelExpression
+            ))
+            ->process(fn(string $eelExpression) => preg_replace(
+                '/(node|documentNode|site)\.context\.currentRenderingMode\.edit/',
+                'renderingMode.isEdit',
+                $eelExpression
+            ))
+            ->process(fn(string $eelExpression) => preg_replace(
+                '/(node|documentNode|site)\.context\.currentRenderingMode\.preview/',
+                'renderingMode.isPreview',
+                $eelExpression
+            ))
+            ->addCommentsIfRegexMatches(
+                '/\.context\.currentRenderingMode/',
+                '// TODO 9.0 migration: Line %LINE: You very likely need to rewrite "VARIABLE.context.currentRenderingMode..." to "renderingMode...". We did not auto-apply this migration because we cannot be sure whether the variable is a Node.'
+            )->getProcessedContent();
+    }
+}

--- a/tests/ContentRepository90/Rules/FusionContextCurrentRenderingModeRector/Fixture/some_file.fusion.inc
+++ b/tests/ContentRepository90/Rules/FusionContextCurrentRenderingModeRector/Fixture/some_file.fusion.inc
@@ -1,0 +1,42 @@
+prototype(Neos.Fusion.Form:Checkbox)  < prototype(Neos.Fusion.Form:Component.Field) {
+
+  renderer = Neos.Fusion:Component {
+
+    nodeAttributes = ${node.context.currentRenderingMode.edit || node.context.currentRenderingMode.preview || node.context.currentRenderingMode.title || node.context.currentRenderingMode.name || node.context.currentRenderingMode.fusionPath || node.context.currentRenderingMode.options['foo']}
+    siteAttributes = ${site.context.currentRenderingMode.edit || site.context.currentRenderingMode.preview || site.context.currentRenderingMode.title || site.context.currentRenderingMode.name || site.context.currentRenderingMode.fusionPath || site.context.currentRenderingMode.options['foo']}
+    documentNodeAttributes = ${documentNode.context.currentRenderingMode.edit || documentNode.context.currentRenderingMode.preview || documentNode.context.currentRenderingMode.title || documentNode.context.currentRenderingMode.name || documentNode.context.currentRenderingMode.fusionPath || documentNode.context.currentRenderingMode.options['foo']}
+    other = ${other.context.currentRenderingMode.edit || other.context.currentRenderingMode.preview || other.context.currentRenderingMode.title || other.context.currentRenderingMode.name || other.context.currentRenderingMode.fusionPath || other.context.currentRenderingMode.options['foo']}
+
+    renderer = afx`
+      <input
+        type="checkbox"
+        name={node.context.currentRenderingMode.name}
+        value={node.context.currentRenderingMode.title}
+        checked={node.context.currentRenderingMode.edit}
+        {...node.context.currentRenderingMode.options}
+      />
+    `
+  }
+}
+-----
+// TODO 9.0 migration: Line 9: You very likely need to rewrite "VARIABLE.context.currentRenderingMode..." to "renderingMode...". We did not auto-apply this migration because we cannot be sure whether the variable is a Node.
+prototype(Neos.Fusion.Form:Checkbox)  < prototype(Neos.Fusion.Form:Component.Field) {
+
+  renderer = Neos.Fusion:Component {
+
+    nodeAttributes = ${renderingMode.isEdit || renderingMode.isPreview || renderingMode.title || renderingMode.name || renderingMode.fusionPath || renderingMode.options['foo']}
+    siteAttributes = ${renderingMode.isEdit || renderingMode.isPreview || renderingMode.title || renderingMode.name || renderingMode.fusionPath || renderingMode.options['foo']}
+    documentNodeAttributes = ${renderingMode.isEdit || renderingMode.isPreview || renderingMode.title || renderingMode.name || renderingMode.fusionPath || renderingMode.options['foo']}
+    other = ${other.context.currentRenderingMode.edit || other.context.currentRenderingMode.preview || other.context.currentRenderingMode.title || other.context.currentRenderingMode.name || other.context.currentRenderingMode.fusionPath || other.context.currentRenderingMode.options['foo']}
+
+    renderer = afx`
+      <input
+        type="checkbox"
+        name={renderingMode.name}
+        value={renderingMode.title}
+        checked={renderingMode.isEdit}
+        {...renderingMode.options}
+      />
+    `
+  }
+}

--- a/tests/ContentRepository90/Rules/FusionContextCurrentRenderingModeRector/FusionContextCurrentRenderingModeRectorTest.php
+++ b/tests/ContentRepository90/Rules/FusionContextCurrentRenderingModeRector/FusionContextCurrentRenderingModeRectorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\Rector\Tests\ContentRepository90\Rules\FusionContextCurrentRenderingModeRector;
+
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class FusionContextCurrentRenderingModeRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(string $fileInfo): void
+    {
+        $this->doTestFile($fileInfo);
+    }
+
+    /**
+     * @return \Iterator<string>
+     */
+    public function provideData(): \Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture', '*.fusion.inc');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/ContentRepository90/Rules/FusionContextCurrentRenderingModeRector/config/configured_rule.php
+++ b/tests/ContentRepository90/Rules/FusionContextCurrentRenderingModeRector/config/configured_rule.php
@@ -1,0 +1,17 @@
+<?php
+
+declare (strict_types=1);
+use Neos\Rector\ContentRepository90\Rules\FusionContextCurrentRenderingModeRector;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig) : void {
+    $services = $rectorConfig->services();
+    $services->defaults()
+        ->public()
+        ->autowire()
+        ->autoconfigure();
+    $services->set(\Neos\Rector\Core\FusionProcessing\FusionFileProcessor::class);
+    $rectorConfig->disableParallel(); // does not work for fusion files - see https://github.com/rectorphp/rector-src/pull/2597#issuecomment-1190120688
+
+    $rectorConfig->rule(FusionContextCurrentRenderingModeRector::class);
+};


### PR DESCRIPTION
Statements accessing using`(node|documentNode|site).context.currentRenderingMode.(edit|preview|name|title|fusionPath|options)` are migrated. Other uses of `context.currentRenderingMode` are marked with a comment.

Resolves: #23