### PR TITLE
TASK Refactor ContentContext methods

### DIFF
--- a/config/set/contentrepository-90.php
+++ b/config/set/contentrepository-90.php
@@ -286,7 +286,7 @@ return static function (RectorConfig $rectorConfig): void {
     $methodCallToWarningComments[] = new MethodCallToWarningComment(LegacyContextStub::class, 'getCurrentDomain', '!! ContentContext::getCurrentDomain() is removed in Neos 9.0.');
     $fusionNodePropertyPathToWarningComments[] = new FusionNodePropertyPathToWarningComment('context.currentDomain', 'Line %LINE: !! node.context.currentDomain is removed in Neos 9.0.');
     // ContentContext::getCurrentSiteNode
-    $methodCallToWarningComments[] = new MethodCallToWarningComment(LegacyContextStub::class, 'getCurrentSiteNode', '!! ContentContext::getCurrentSiteNode() is removed in Neos 9.0.');
+    $methodCallToWarningComments[] = new MethodCallToWarningComment(LegacyContextStub::class, 'getCurrentSiteNode', '!! ContentContext::getCurrentSiteNode() is removed in Neos 9.0. Use Subgraph and traverse up to "Neos.Neos:Site" node.');
     $fusionNodePropertyPathToWarningComments[] = new FusionNodePropertyPathToWarningComment('context.currentSiteNode', 'Line %LINE: !! node.context.currentSiteNode is removed in Neos 9.0.');
     // ContentContext::isLive -> renderingMode.isLive
     $rectorConfig->rule(ContextIsLiveRector::class);

--- a/config/set/contentrepository-90.php
+++ b/config/set/contentrepository-90.php
@@ -21,7 +21,6 @@ use Neos\Rector\Generic\Rules\InjectServiceIfNeededRector;
 use Neos\Rector\ContentRepository90\Rules\NodeFactoryResetRector;
 use Neos\Rector\ContentRepository90\Rules\NodeFindParentNodeRector;
 use Neos\Rector\ContentRepository90\Rules\NodeGetChildNodesRector;
-use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
 use Neos\Rector\ContentRepository90\Rules\NodeGetContextGetWorkspaceNameRector;
 use Neos\Rector\ContentRepository90\Rules\NodeGetContextGetWorkspaceRector;
 use Neos\Rector\ContentRepository90\Rules\NodeGetDepthRector;
@@ -50,6 +49,11 @@ use Neos\Rector\ContentRepository90\Rules\FusionNodeTypeNameRector;
 use Neos\Rector\ContentRepository90\Rules\NodeTypeGetNameRector;
 use Neos\Rector\Generic\ValueObject\AddInjection;
 use Neos\ContentRepositoryRegistry\ContentRepositoryRegistry;
+use Neos\Neos\Domain\Service\RenderingModeService;
+use Neos\Rector\ContentRepository90\Rules\ContextGetCurrentRenderingModeRector;
+use Neos\Rector\ContentRepository90\Legacy\NodeLegacyStub;
+use Neos\Rector\ContentRepository90\Rules\ContextIsLiveRector;
+use Neos\Rector\ContentRepository90\Rules\ContextIsInBackendRector;
 
 return static function (RectorConfig $rectorConfig): void {
     // Register FusionFileProcessor. All Fusion Rectors will be auto-registered at this processor.
@@ -64,9 +68,9 @@ return static function (RectorConfig $rectorConfig): void {
 
 
     $rectorConfig->ruleWithConfiguration(RenameClassRector::class, [
-        'Neos\\ContentRepository\\Domain\\Model\\NodeInterface' => Node::class,
-        'Neos\\ContentRepository\\Domain\\Projection\\Content\\NodeInterface' => Node::class,
-        'Neos\\ContentRepository\\Domain\\Projection\\Content\\TraversableNodeInterface' => Node::class,
+        'Neos\\ContentRepository\\Domain\\Model\\NodeInterface' => NodeLegacyStub::class,
+        'Neos\\ContentRepository\\Domain\\Projection\\Content\\NodeInterface' => NodeLegacyStub::class,
+        'Neos\\ContentRepository\\Domain\\Projection\\Content\\TraversableNodeInterface' => NodeLegacyStub::class,
 
         'Neos\ContentRepository\Domain\Service\Context' => LegacyContextStub::class,
         'Neos\Neos\Domain\Service\ContentContext' => LegacyContextStub::class,
@@ -92,37 +96,37 @@ return static function (RectorConfig $rectorConfig): void {
      */
     // setName
     // getName
-    $methodCallToPropertyFetches[] = new MethodCallToPropertyFetch(Node::class, 'getName', 'nodeName');
+    $methodCallToPropertyFetches[] = new MethodCallToPropertyFetch(NodeLegacyStub::class, 'getName', 'nodeName');
     // getLabel -> compatible with ES CR node (nothing to do)
     // setProperty
     // hasProperty -> compatible with ES CR Node (nothing to do)
     // getProperty -> compatible with ES CR Node (nothing to do)
     // removeProperty
     // getProperties -> PropertyCollectionInterface
-    $methodCallToPropertyFetches[] = new MethodCallToPropertyFetch(Node::class, 'getProperties', 'properties');
+    $methodCallToPropertyFetches[] = new MethodCallToPropertyFetch(NodeLegacyStub::class, 'getProperties', 'properties');
     // getPropertyNames
     // setContentObject -> DEPRECATED / NON-FUNCTIONAL
-    $methodCallToWarningComments[] = new MethodCallToWarningComment(Node::class, 'setContentObject', '!! Node::setContentObject() is not supported by the new CR. Referencing objects can be done by storing them in Node::properties (and the serialization/deserialization is extensible).');
+    $methodCallToWarningComments[] = new MethodCallToWarningComment(NodeLegacyStub::class, 'setContentObject', '!! Node::setContentObject() is not supported by the new CR. Referencing objects can be done by storing them in Node::properties (and the serialization/deserialization is extensible).');
     // getContentObject -> DEPRECATED / NON-FUNCTIONAL
-    $methodCallToWarningComments[] = new MethodCallToWarningComment(Node::class, 'getContentObject', '!! Node::getContentObject() is not supported by the new CR. Referencing objects can be done by storing them in Node::properties (and the serialization/deserialization is extensible).');
+    $methodCallToWarningComments[] = new MethodCallToWarningComment(NodeLegacyStub::class, 'getContentObject', '!! Node::getContentObject() is not supported by the new CR. Referencing objects can be done by storing them in Node::properties (and the serialization/deserialization is extensible).');
     // unsetContentObject -> DEPRECATED / NON-FUNCTIONAL
-    $methodCallToWarningComments[] = new MethodCallToWarningComment(Node::class, 'unsetContentObject', '!! Node::unsetContentObject() is not supported by the new CR. Referencing objects can be done by storing them in Node::properties (and the serialization/deserialization is extensible).');
+    $methodCallToWarningComments[] = new MethodCallToWarningComment(NodeLegacyStub::class, 'unsetContentObject', '!! Node::unsetContentObject() is not supported by the new CR. Referencing objects can be done by storing them in Node::properties (and the serialization/deserialization is extensible).');
     // setNodeType
     // getNodeType: NodeType
-    $methodCallToPropertyFetches[] = new MethodCallToPropertyFetch(Node::class, 'getNodeType', 'nodeType');
+    $methodCallToPropertyFetches[] = new MethodCallToPropertyFetch(NodeLegacyStub::class, 'getNodeType', 'nodeType');
     // setHidden
     // isHidden
     $rectorConfig->rule(NodeIsHiddenRector::class);
         // TODO: Fusion NodeAccess
     // setHiddenBeforeDateTime
-    $methodCallToWarningComments[] = new MethodCallToWarningComment(Node::class, 'setHiddenBeforeDateTime', '!! Node::setHiddenBeforeDateTime() is not supported by the new CR. Timed publishing will be implemented not on the read model, but by dispatching commands at a given time.');
+    $methodCallToWarningComments[] = new MethodCallToWarningComment(NodeLegacyStub::class, 'setHiddenBeforeDateTime', '!! Node::setHiddenBeforeDateTime() is not supported by the new CR. Timed publishing will be implemented not on the read model, but by dispatching commands at a given time.');
     // getHiddenBeforeDateTime
-    $methodCallToWarningComments[] = new MethodCallToWarningComment(Node::class, 'getHiddenBeforeDateTime', '!! Node::getHiddenBeforeDateTime() is not supported by the new CR. Timed publishing will be implemented not on the read model, but by dispatching commands at a given time.');
+    $methodCallToWarningComments[] = new MethodCallToWarningComment(NodeLegacyStub::class, 'getHiddenBeforeDateTime', '!! Node::getHiddenBeforeDateTime() is not supported by the new CR. Timed publishing will be implemented not on the read model, but by dispatching commands at a given time.');
     $fusionNodePropertyPathToWarningComments[] = new FusionNodePropertyPathToWarningComment('hiddenBeforeDateTime', 'Line %LINE: !! node.hiddenBeforeDateTime is not supported by the new CR. Timed publishing will be implemented not on the read model, but by dispatching commands at a given time.');
     // setHiddenAfterDateTime
-    $methodCallToWarningComments[] = new MethodCallToWarningComment(Node::class, 'setHiddenAfterDateTime', '!! Node::setHiddenAfterDateTime() is not supported by the new CR. Timed publishing will be implemented not on the read model, but by dispatching commands at a given time.');
+    $methodCallToWarningComments[] = new MethodCallToWarningComment(NodeLegacyStub::class, 'setHiddenAfterDateTime', '!! Node::setHiddenAfterDateTime() is not supported by the new CR. Timed publishing will be implemented not on the read model, but by dispatching commands at a given time.');
     // getHiddenAfterDateTime
-    $methodCallToWarningComments[] = new MethodCallToWarningComment(Node::class, 'getHiddenAfterDateTime', '!! Node::getHiddenAfterDateTime() is not supported by the new CR. Timed publishing will be implemented not on the read model, but by dispatching commands at a given time.');
+    $methodCallToWarningComments[] = new MethodCallToWarningComment(NodeLegacyStub::class, 'getHiddenAfterDateTime', '!! Node::getHiddenAfterDateTime() is not supported by the new CR. Timed publishing will be implemented not on the read model, but by dispatching commands at a given time.');
     $fusionNodePropertyPathToWarningComments[] = new FusionNodePropertyPathToWarningComment('hiddenAfterDateTime', 'Line %LINE: !! node.hiddenAfterDateTime is not supported by the new CR. Timed publishing will be implemented not on the read model, but by dispatching commands at a given time.');
     // setHiddenInIndex
     // isHiddenInIndex
@@ -130,9 +134,9 @@ return static function (RectorConfig $rectorConfig): void {
     // Fusion: .hiddenInIndex -> node.properties._hiddenInIndex
     $rectorConfig->rule(FusionNodeHiddenInIndexRector::class);
     // setAccessRoles
-    $methodCallToWarningComments[] = new MethodCallToWarningComment(Node::class, 'setAccessRoles', '!! Node::setAccessRoles() is not supported by the new CR.');
+    $methodCallToWarningComments[] = new MethodCallToWarningComment(NodeLegacyStub::class, 'setAccessRoles', '!! Node::setAccessRoles() is not supported by the new CR.');
     // getAccessRoles
-    $methodCallToWarningComments[] = new MethodCallToWarningComment(Node::class, 'getAccessRoles', '!! Node::getAccessRoles() is not supported by the new CR.');
+    $methodCallToWarningComments[] = new MethodCallToWarningComment(NodeLegacyStub::class, 'getAccessRoles', '!! Node::getAccessRoles() is not supported by the new CR.');
     // getPath
     $rectorConfig->rule(NodeGetPathRector::class);
     // Fusion: .depth -> Neos.NodeAccess.depth(node)
@@ -146,16 +150,16 @@ return static function (RectorConfig $rectorConfig): void {
     // Fusion: .depth -> Neos.Node.depth(node)
     $rectorConfig->rule(FusionNodeDepthRector::class);
     // setWorkspace -> internal
-    $methodCallToWarningComments[] = new MethodCallToWarningComment(Node::class, 'setWorkspace', '!! Node::setWorkspace() was always internal, and the workspace system has been fundamentally changed with the new CR. Try to rewrite your code around Content Streams.');
+    $methodCallToWarningComments[] = new MethodCallToWarningComment(NodeLegacyStub::class, 'setWorkspace', '!! Node::setWorkspace() was always internal, and the workspace system has been fundamentally changed with the new CR. Try to rewrite your code around Content Streams.');
     // getWorkspace
-    $methodCallToWarningComments[] = new MethodCallToWarningComment(Node::class, 'getWorkspace', '!! Node::getWorkspace() does not make sense anymore concept-wise. In Neos < 9, it pointed to the workspace where the node was *at home at*. Now, the closest we have here is the node identity.');
+    $methodCallToWarningComments[] = new MethodCallToWarningComment(NodeLegacyStub::class, 'getWorkspace', '!! Node::getWorkspace() does not make sense anymore concept-wise. In Neos < 9, it pointed to the workspace where the node was *at home at*. Now, the closest we have here is the node identity.');
     // getIdentifier
     $rectorConfig->rule(NodeGetIdentifierRector::class);
     $rectorConfig->rule(FusionNodeIdentifierRector::class);
     // setIndex -> internal
-    $methodCallToWarningComments[] = new MethodCallToWarningComment(Node::class, 'setIndex', '!! Node::setIndex() was always internal. To reorder nodes, use the "MoveNodeAggregate" command');
+    $methodCallToWarningComments[] = new MethodCallToWarningComment(NodeLegacyStub::class, 'setIndex', '!! Node::setIndex() was always internal. To reorder nodes, use the "MoveNodeAggregate" command');
     // getIndex
-    $methodCallToWarningComments[] = new MethodCallToWarningComment(Node::class, 'getIndex', '!! Node::getIndex() is not supported. You can fetch all siblings and inspect the ordering');
+    $methodCallToWarningComments[] = new MethodCallToWarningComment(NodeLegacyStub::class, 'getIndex', '!! Node::getIndex() is not supported. You can fetch all siblings and inspect the ordering');
     // getParent -> Node
     $rectorConfig->rule(NodeGetParentRector::class);
     // Fusion: .parent -> Neos.NodeAccess.findParent(node)
@@ -172,7 +176,7 @@ return static function (RectorConfig $rectorConfig): void {
     // remove()
     // setRemoved()
     // isRemoved()
-    $methodCallToWarningComments[] = new MethodCallToWarningComment(Node::class, 'isRemoved', '!! Node::isRemoved() - the new CR *never* returns removed nodes; so you can simplify your code and just assume removed == FALSE in all scenarios.');
+    $methodCallToWarningComments[] = new MethodCallToWarningComment(NodeLegacyStub::class, 'isRemoved', '!! Node::isRemoved() - the new CR *never* returns removed nodes; so you can simplify your code and just assume removed == FALSE in all scenarios.');
     $fusionNodePropertyPathToWarningComments[] = new FusionNodePropertyPathToWarningComment('removed', 'Line %LINE: !! node.removed - the new CR *never* returns removed nodes; so you can simplify your code and just assume removed == FALSE in all scenarios.');
     // isVisible()
     // isAccessible()
@@ -185,7 +189,7 @@ return static function (RectorConfig $rectorConfig): void {
     // copyAfter()
     // copyInto()
     // getNodeData()
-    $methodCallToWarningComments[] = new MethodCallToWarningComment(Node::class, 'getNodeData', '!! Node::getNodeData() - the new CR is not based around the concept of NodeData anymore. You need to rewrite your code here.');
+    $methodCallToWarningComments[] = new MethodCallToWarningComment(NodeLegacyStub::class, 'getNodeData', '!! Node::getNodeData() - the new CR is not based around the concept of NodeData anymore. You need to rewrite your code here.');
     // getContext()
     // getContext()->getWorkspace()
     $rectorConfig->rule(NodeGetContextGetWorkspaceRector::class);
@@ -207,13 +211,13 @@ return static function (RectorConfig $rectorConfig): void {
     // isTethered()
     // getContentStreamIdentifier() -> threw exception in <= Neos 8.0 - so nobody could have used this
     // getNodeAggregateIdentifier()
-    $methodCallToPropertyFetches[] = new MethodCallToPropertyFetch(Node::class, 'getNodeAggregateIdentifier', 'nodeAggregateId');
+    $methodCallToPropertyFetches[] = new MethodCallToPropertyFetch(NodeLegacyStub::class, 'getNodeAggregateIdentifier', 'nodeAggregateId');
     $rectorConfig->rule(rectorClass: FusionNodeAggregateIdentifierRector::class);
     // getNodeTypeName()
-    $methodCallToPropertyFetches[] = new MethodCallToPropertyFetch(Node::class, 'getNodeTypeName', 'nodeTypeName');
+    $methodCallToPropertyFetches[] = new MethodCallToPropertyFetch(NodeLegacyStub::class, 'getNodeTypeName', 'nodeTypeName');
     // getNodeType() ** (included/compatible in old NodeInterface)
     // getNodeName()
-    $methodCallToPropertyFetches[] = new MethodCallToPropertyFetch(Node::class, 'getNodeName', 'nodeName');
+    $methodCallToPropertyFetches[] = new MethodCallToPropertyFetch(NodeLegacyStub::class, 'getNodeName', 'nodeName');
     // getOriginDimensionSpacePoint() -> threw exception in <= Neos 8.0 - so nobody could have used this
     // getProperties() ** (included/compatible in old NodeInterface)
     // getProperty() ** (included/compatible in old NodeInterface)
@@ -275,23 +279,22 @@ return static function (RectorConfig $rectorConfig): void {
      * ContentContext
      */
     // ContentContext::getCurrentSite
-    // TODO: PHP
+    $methodCallToWarningComments[] = new MethodCallToWarningComment(LegacyContextStub::class, 'getCurrentSite', '!! ContentContext::getCurrentSite() is removed in Neos 9.0.');
     $rectorConfig->rule(FusionContextCurrentSiteRector::class);
-    // TODO: Fusion
     // ContentContext::getCurrentDomain
-    // TODO: PHP
-    // TODO: Fusion
+    $methodCallToWarningComments[] = new MethodCallToWarningComment(LegacyContextStub::class, 'getCurrentDomain', '!! ContentContext::getCurrentDomain() is removed in Neos 9.0.');
+    $fusionNodePropertyPathToWarningComments[] = new FusionNodePropertyPathToWarningComment('context.currentDomain', 'Line %LINE: !! node.context.currentDomain is removed in Neos 9.0.');
     // ContentContext::getCurrentSiteNode
-    // TODO: PHP
-    // TODO: Fusion
+    $methodCallToWarningComments[] = new MethodCallToWarningComment(LegacyContextStub::class, 'getCurrentSiteNode', '!! ContentContext::getCurrentSiteNode() is removed in Neos 9.0.');
+    $fusionNodePropertyPathToWarningComments[] = new FusionNodePropertyPathToWarningComment('context.currentSiteNode', 'Line %LINE: !! node.context.currentSiteNode is removed in Neos 9.0.');
     // ContentContext::isLive -> renderingMode.isLive
-    // TODO: PHP
+    $rectorConfig->rule(ContextIsLiveRector::class);
     $rectorConfig->rule(FusionContextLiveRector::class);
     // ContentContext::isInBackend -> renderingMode.inBackend
-    // TODO: PHP
+    $rectorConfig->rule(ContextIsInBackendRector::class);
     $rectorConfig->rule(FusionContextInBackendRector::class);
     // ContentContext::getCurrentRenderingMode... -> renderingMode...
-    // TODO: PHP
+    $rectorConfig->rule(ContextGetCurrentRenderingModeRector::class);
     $rectorConfig->rule(FusionContextCurrentRenderingModeRector::class);
 
 
@@ -379,9 +382,14 @@ return static function (RectorConfig $rectorConfig): void {
         \Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateIds::class => 'toJson()',
     ]);
 
+    $rectorConfig->ruleWithConfiguration(RenameClassRector::class, [
+        LegacyContextStub::class => NodeLegacyStub::class,
+    ]);
+
     // Should run LAST - as other rules above might create $this->contentRepositoryRegistry calls.
     $rectorConfig->ruleWithConfiguration(InjectServiceIfNeededRector::class, [
         new AddInjection('contentRepositoryRegistry', ContentRepositoryRegistry::class),
+        new AddInjection('renderingModeService', RenderingModeService::class),
     ]);
     // TODO: does not fully seem to work.$rectorConfig->rule(RemoveDuplicateCommentRector::class);
 };

--- a/config/set/contentrepository-90.php
+++ b/config/set/contentrepository-90.php
@@ -54,6 +54,7 @@ use Neos\Rector\ContentRepository90\Rules\ContextGetCurrentRenderingModeRector;
 use Neos\Rector\ContentRepository90\Legacy\NodeLegacyStub;
 use Neos\Rector\ContentRepository90\Rules\ContextIsLiveRector;
 use Neos\Rector\ContentRepository90\Rules\ContextIsInBackendRector;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
 
 return static function (RectorConfig $rectorConfig): void {
     // Register FusionFileProcessor. All Fusion Rectors will be auto-registered at this processor.
@@ -383,7 +384,7 @@ return static function (RectorConfig $rectorConfig): void {
     ]);
 
     $rectorConfig->ruleWithConfiguration(RenameClassRector::class, [
-        LegacyContextStub::class => NodeLegacyStub::class,
+        NodeLegacyStub::class => Node::class,
     ]);
 
     // Should run LAST - as other rules above might create $this->contentRepositoryRegistry calls.

--- a/src/ContentRepository90/Legacy/NodeLegacyStub.php
+++ b/src/ContentRepository90/Legacy/NodeLegacyStub.php
@@ -11,8 +11,4 @@ class NodeLegacyStub
     public function getContext() : LegacyContextStub {
         return new LegacyContextStub([]);
     }
-
-    public function isLive() :bool {
-        return false;
-    }
 }

--- a/src/ContentRepository90/Legacy/NodeLegacyStub.php
+++ b/src/ContentRepository90/Legacy/NodeLegacyStub.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Neos\Rector\ContentRepository90\Legacy;
+
+/**
+ * @deprecated
+ */
+class NodeLegacyStub
+{
+
+    public function getContext() : LegacyContextStub {
+        return new LegacyContextStub([]);
+    }
+
+    public function isLive() :bool {
+        return false;
+    }
+}

--- a/src/ContentRepository90/Rules/ContextGetCurrentRenderingModeRector.php
+++ b/src/ContentRepository90/Rules/ContextGetCurrentRenderingModeRector.php
@@ -1,0 +1,63 @@
+<?php
+
+declare (strict_types=1);
+
+namespace Neos\Rector\ContentRepository90\Rules;
+
+use Neos\Rector\Utility\CodeSampleLoader;
+use PhpParser\Node;
+use PHPStan\Type\ObjectType;
+use Rector\Core\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use Rector\PostRector\Collector\NodesToAddCollector;
+use PhpParser\Node\Expr\Assign;
+
+final class ContextGetCurrentRenderingModeRector extends AbstractRector
+{
+    use AllTraits;
+    use ContextRectorTrait;
+
+    public function __construct(
+        private readonly NodesToAddCollector $nodesToAddCollector
+    ) {
+    }
+
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return CodeSampleLoader::fromFile('"ContentContext::getCurrentRenderingMode()" will be replaced with RenderingModeService::findByCurrentUser().', __CLASS__);
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Node\Expr\MethodCall::class];
+    }
+
+    /**
+     * @param \PhpParser\Node\Stmt\Expression $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        assert($node instanceof Node\Expr\MethodCall);
+
+        $oldContextMethod = 'getCurrentRenderingMode';
+        if (
+            $this->isContextWithMethod($node, $oldContextMethod)
+        ) {
+
+            return $this->nodeFactory->createMethodCall(
+                $this->nodeFactory->createPropertyFetch(
+                    'this',
+                    'renderingModeService'
+                ),
+                'findByCurrentUser'
+            );
+        }
+
+        return null;
+    }
+
+}

--- a/src/ContentRepository90/Rules/ContextIsInBackendRector.php
+++ b/src/ContentRepository90/Rules/ContextIsInBackendRector.php
@@ -1,0 +1,67 @@
+<?php
+
+declare (strict_types=1);
+
+namespace Neos\Rector\ContentRepository90\Rules;
+
+use Neos\Rector\Utility\CodeSampleLoader;
+use PhpParser\Node;
+use PHPStan\Type\ObjectType;
+use Rector\Core\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use Rector\PostRector\Collector\NodesToAddCollector;
+use PhpParser\Node\Expr\Assign;
+use PhpParser\NodeDumper;
+
+final class ContextIsInBackendRector extends AbstractRector
+{
+    use AllTraits;
+    use ContextRectorTrait;
+
+    public function __construct(
+        private readonly NodesToAddCollector $nodesToAddCollector
+    ) {
+    }
+
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return CodeSampleLoader::fromFile('"ContentContext::isLive()" will be replaced with RenderingModeService::findByCurrentUser().', __CLASS__);
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Node\Expr\MethodCall::class];
+    }
+
+    /**
+     * @param \PhpParser\Node\Stmt\Expression $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        assert($node instanceof Node\Expr\MethodCall);
+
+        $oldContextMethod = 'isInBackend';
+        if ($this->isContextWithMethod($node, $oldContextMethod)) {
+
+            $renderingModeService = $this->nodeFactory->createMethodCall(
+                $this->nodeFactory->createPropertyFetch(
+                    'this',
+                    'renderingModeService'
+                ),
+                'findByCurrentUser'
+            );
+
+            return $this->nodeFactory->createPropertyFetch(
+                $renderingModeService, 'isEdit'
+            );
+
+        }
+
+        return null;
+    }
+
+}

--- a/src/ContentRepository90/Rules/ContextIsLiveRector.php
+++ b/src/ContentRepository90/Rules/ContextIsLiveRector.php
@@ -1,0 +1,80 @@
+<?php
+
+declare (strict_types=1);
+
+namespace Neos\Rector\ContentRepository90\Rules;
+
+use Neos\Rector\Utility\CodeSampleLoader;
+use PhpParser\Node;
+use PHPStan\Type\ObjectType;
+use Rector\Core\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use Rector\PostRector\Collector\NodesToAddCollector;
+use PhpParser\Node\Expr\Assign;
+use PhpParser\NodeDumper;
+
+final class ContextIsLiveRector extends AbstractRector
+{
+    use AllTraits;
+    use ContextRectorTrait;
+
+    public function __construct(
+        private readonly NodesToAddCollector $nodesToAddCollector
+    ) {
+    }
+
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return CodeSampleLoader::fromFile('"ContentContext::isLive()" will be replaced with RenderingModeService::findByCurrentUser().', __CLASS__);
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Node\Expr\MethodCall::class];
+    }
+
+    /**
+     * @param \PhpParser\Node\Stmt\Expression $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        assert($node instanceof Node\Expr\MethodCall);
+
+        $oldContextMethod = 'isLive';
+        if ($this->isContextWithMethod($node, $oldContextMethod)) {
+
+            $renderingModeService = $this->nodeFactory->createMethodCall(
+                $this->nodeFactory->createPropertyFetch(
+                    'this',
+                    'renderingModeService'
+                ),
+                'findByCurrentUser'
+            );
+
+            $isEdit = $this->nodeFactory->createPropertyFetch(
+                $renderingModeService, 'isEdit'
+            );
+            $isPreview = $this->nodeFactory->createPropertyFetch(
+                $renderingModeService, 'isPreview'
+            );
+
+            $replacementExpression = new Node\Expr\BinaryOp\BooleanAnd(
+                new Node\Expr\BooleanNot(
+                    $isEdit
+                ),
+                new Node\Expr\BooleanNot(
+                    $isPreview
+                ),
+            );
+
+            return $replacementExpression;
+        }
+
+        return null;
+    }
+
+}

--- a/src/ContentRepository90/Rules/ContextRectorTrait.php
+++ b/src/ContentRepository90/Rules/ContextRectorTrait.php
@@ -1,0 +1,27 @@
+<?php
+
+declare (strict_types=1);
+
+namespace Neos\Rector\ContentRepository90\Rules;
+
+use Neos\Rector\Utility\CodeSampleLoader;
+use PhpParser\Node;
+use PhpParser\NodeFinder;
+use PHPStan\Type\ObjectType;
+use Rector\Core\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use Rector\PostRector\Collector\NodesToAddCollector;
+use PhpParser\Node\Expr\Assign;
+use PhpParser\NodeDumper;
+
+trait ContextRectorTrait
+{
+    private function isContextWithMethod(Node\Expr\MethodCall $node, string $methodName): bool
+    {
+        return (
+            $node->name == $methodName
+            && $this->isObjectType($node->var, new ObjectType('Neos\Rector\ContentRepository90\Legacy\LegacyContextStub')
+            )
+        );
+    }
+}

--- a/src/ContentRepository90/Rules/NodeFindParentNodeRector.php
+++ b/src/ContentRepository90/Rules/NodeFindParentNodeRector.php
@@ -41,7 +41,7 @@ final class NodeFindParentNodeRector extends AbstractRector
     {
         assert($node instanceof Node\Expr\MethodCall);
 
-        if (!$this->isObjectType($node->var, new ObjectType(\Neos\ContentRepository\Core\Projection\ContentGraph\Node::class))) {
+        if (!$this->isObjectType($node->var, new ObjectType(\Neos\Rector\ContentRepository90\Legacy\NodeLegacyStub::class))) {
             return null;
         }
         if (!$this->isName($node->name, 'findParentNode')) {

--- a/src/ContentRepository90/Rules/NodeGetChildNodesRector.php
+++ b/src/ContentRepository90/Rules/NodeGetChildNodesRector.php
@@ -39,7 +39,7 @@ final class NodeGetChildNodesRector extends AbstractRector
     {
         assert($node instanceof Node\Expr\MethodCall);
 
-        if (!$this->isObjectType($node->var, new ObjectType(\Neos\ContentRepository\Core\Projection\ContentGraph\Node::class))) {
+        if (!$this->isObjectType($node->var, new ObjectType(\Neos\Rector\ContentRepository90\Legacy\NodeLegacyStub::class))) {
             return null;
         }
         if (!$this->isName($node->name, 'getChildNodes')) {

--- a/src/ContentRepository90/Rules/NodeGetContextGetWorkspaceNameRector.php
+++ b/src/ContentRepository90/Rules/NodeGetContextGetWorkspaceNameRector.php
@@ -51,7 +51,7 @@ final class NodeGetContextGetWorkspaceNameRector extends AbstractRector
             return null;
         }
 
-        if (!$this->isObjectType($node->var->var, new ObjectType(\Neos\ContentRepository\Core\Projection\ContentGraph\Node::class))) {
+        if (!$this->isObjectType($node->var->var, new ObjectType(\Neos\Rector\ContentRepository90\Legacy\NodeLegacyStub::class))) {
             return null;
         }
 

--- a/src/ContentRepository90/Rules/NodeGetContextGetWorkspaceRector.php
+++ b/src/ContentRepository90/Rules/NodeGetContextGetWorkspaceRector.php
@@ -51,7 +51,7 @@ final class NodeGetContextGetWorkspaceRector extends AbstractRector
             return null;
         }
 
-        if (!$this->isObjectType($node->var->var, new ObjectType(\Neos\ContentRepository\Core\Projection\ContentGraph\Node::class))) {
+        if (!$this->isObjectType($node->var->var, new ObjectType(\Neos\Rector\ContentRepository90\Legacy\NodeLegacyStub::class))) {
             return null;
         }
 

--- a/src/ContentRepository90/Rules/NodeGetDepthRector.php
+++ b/src/ContentRepository90/Rules/NodeGetDepthRector.php
@@ -39,7 +39,7 @@ final class NodeGetDepthRector extends AbstractRector
     {
         assert($node instanceof Node\Expr\MethodCall);
 
-        if (!$this->isObjectType($node->var, new ObjectType(\Neos\ContentRepository\Core\Projection\ContentGraph\Node::class))) {
+        if (!$this->isObjectType($node->var, new ObjectType(\Neos\Rector\ContentRepository90\Legacy\NodeLegacyStub::class))) {
             return null;
         }
         if (!$this->isName($node->name, 'getDepth')) {

--- a/src/ContentRepository90/Rules/NodeGetDimensionsRector.php
+++ b/src/ContentRepository90/Rules/NodeGetDimensionsRector.php
@@ -39,7 +39,7 @@ final class NodeGetDimensionsRector extends AbstractRector
     {
         assert($node instanceof Node\Expr\MethodCall);
 
-        if (!$this->isObjectType($node->var, new ObjectType(\Neos\ContentRepository\Core\Projection\ContentGraph\Node::class))) {
+        if (!$this->isObjectType($node->var, new ObjectType(\Neos\Rector\ContentRepository90\Legacy\NodeLegacyStub::class))) {
             return null;
         }
         if (!$this->isName($node->name, 'getDimensions')) {

--- a/src/ContentRepository90/Rules/NodeGetIdentifierRector.php
+++ b/src/ContentRepository90/Rules/NodeGetIdentifierRector.php
@@ -40,7 +40,7 @@ final class NodeGetIdentifierRector extends AbstractRector
     {
         assert($node instanceof Node\Expr\MethodCall);
 
-        if (!$this->isObjectType($node->var, new ObjectType(\Neos\ContentRepository\Core\Projection\ContentGraph\Node::class))) {
+        if (!$this->isObjectType($node->var, new ObjectType(\Neos\Rector\ContentRepository90\Legacy\NodeLegacyStub::class))) {
             return null;
         }
         if (!$this->isName($node->name, 'getIdentifier')) {

--- a/src/ContentRepository90/Rules/NodeGetParentRector.php
+++ b/src/ContentRepository90/Rules/NodeGetParentRector.php
@@ -39,7 +39,7 @@ final class NodeGetParentRector extends AbstractRector
     {
         assert($node instanceof Node\Expr\MethodCall);
 
-        if (!$this->isObjectType($node->var, new ObjectType(\Neos\ContentRepository\Core\Projection\ContentGraph\Node::class))) {
+        if (!$this->isObjectType($node->var, new ObjectType(\Neos\Rector\ContentRepository90\Legacy\NodeLegacyStub::class))) {
             return null;
         }
         if (!$this->isName($node->name, 'getParent')) {

--- a/src/ContentRepository90/Rules/NodeGetPathRector.php
+++ b/src/ContentRepository90/Rules/NodeGetPathRector.php
@@ -39,7 +39,7 @@ final class NodeGetPathRector extends AbstractRector
     {
         assert($node instanceof Node\Expr\MethodCall);
 
-        if (!$this->isObjectType($node->var, new ObjectType(\Neos\ContentRepository\Core\Projection\ContentGraph\Node::class))) {
+        if (!$this->isObjectType($node->var, new ObjectType(\Neos\Rector\ContentRepository90\Legacy\NodeLegacyStub::class))) {
             return null;
         }
         if (!$this->isName($node->name, 'getPath')) {

--- a/src/ContentRepository90/Rules/NodeIsHiddenInIndexRector.php
+++ b/src/ContentRepository90/Rules/NodeIsHiddenInIndexRector.php
@@ -41,7 +41,7 @@ final class NodeIsHiddenInIndexRector extends AbstractRector
     {
         assert($node instanceof MethodCall);
 
-        if (!$this->isObjectType($node->var, new ObjectType(\Neos\ContentRepository\Core\Projection\ContentGraph\Node::class))) {
+        if (!$this->isObjectType($node->var, new ObjectType(\Neos\Rector\ContentRepository90\Legacy\NodeLegacyStub::class))) {
             return null;
         }
         if (!$this->isName($node->name, 'isHiddenInIndex')) {

--- a/src/ContentRepository90/Rules/NodeIsHiddenRector.php
+++ b/src/ContentRepository90/Rules/NodeIsHiddenRector.php
@@ -41,7 +41,7 @@ final class NodeIsHiddenRector extends AbstractRector
     {
         assert($node instanceof Node\Expr\MethodCall);
 
-        if (!$this->isObjectType($node->var, new ObjectType(\Neos\ContentRepository\Core\Projection\ContentGraph\Node::class))) {
+        if (!$this->isObjectType($node->var, new ObjectType(\Neos\Rector\ContentRepository90\Legacy\NodeLegacyStub::class))) {
             return null;
         }
         if (!$this->isName($node->name, 'isHidden')) {

--- a/src/Generic/Rules/MethodCallToWarningCommentRector.php
+++ b/src/Generic/Rules/MethodCallToWarningCommentRector.php
@@ -13,6 +13,7 @@ use Rector\Core\Rector\AbstractRector;
 use Rector\PostRector\Collector\NodesToAddCollector;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 use Webmozart\Assert\Assert;
+use Neos\Rector\ContentRepository90\Legacy\NodeLegacyStub;
 
 final class MethodCallToWarningCommentRector extends AbstractRector implements ConfigurableRectorInterface
 {
@@ -32,7 +33,7 @@ final class MethodCallToWarningCommentRector extends AbstractRector implements C
     public function getRuleDefinition(): RuleDefinition
     {
         return CodeSampleLoader::fromFile('"Warning comments for various non-supported use cases', __CLASS__, [
-            new MethodCallToWarningComment(Node::class, 'getWorkspace', '!! Node::getWorkspace() does not make sense anymore concept-wise. In Neos < 9, it pointed to the workspace where the node was *at home at*. Now, the closest we have here is the node identity.')
+            new MethodCallToWarningComment(NodeLegacyStub::class, 'getWorkspace', '!! Node::getWorkspace() does not make sense anymore concept-wise. In Neos < 9, it pointed to the workspace where the node was *at home at*. Now, the closest we have here is the node identity.')
         ]);
     }
 

--- a/tests/ContentRepository90/Rules/ContextGetCurrentRenderingModeRector/ContextGetCurrentRenderingModeRectorTest.php
+++ b/tests/ContentRepository90/Rules/ContextGetCurrentRenderingModeRector/ContextGetCurrentRenderingModeRectorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\Rector\Tests\ContentRepository90\Rules\ContextGetFirstLevelNodeCacheRector;
+
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class ContextGetCurrentRenderingModeRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(string $fileInfo): void
+    {
+        $this->doTestFile($fileInfo);
+    }
+
+    /**
+     * @return \Iterator<string>
+     */
+    public function provideData(): \Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/ContentRepository90/Rules/ContextGetCurrentRenderingModeRector/Fixture/some_class.php.inc
+++ b/tests/ContentRepository90/Rules/ContextGetCurrentRenderingModeRector/Fixture/some_class.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+class SomeClass
+{
+    public function run(\Neos\Rector\ContentRepository90\Legacy\LegacyContextStub $context)
+    {
+        $renderingMode = $context->getCurrentRenderingMode();
+    }
+}
+
+?>
+-----
+<?php
+
+class SomeClass
+{
+    #[\Neos\Flow\Annotations\Inject]
+    protected \Neos\Neos\Domain\Service\RenderingModeService $renderingModeService;
+    public function run(\Neos\Rector\ContentRepository90\Legacy\LegacyContextStub $context)
+    {
+        $renderingMode = $this->renderingModeService->findByCurrentUser();
+    }
+}
+
+?>

--- a/tests/ContentRepository90/Rules/ContextGetCurrentRenderingModeRector/Fixture/some_class2.php.inc
+++ b/tests/ContentRepository90/Rules/ContextGetCurrentRenderingModeRector/Fixture/some_class2.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+class SomeClass
+{
+    public function run(\Neos\Rector\ContentRepository90\Legacy\NodeLegacyStub $node)
+    {
+        $context = $node->getContext();
+        $renderingMode = $context->getCurrentRenderingMode();
+    }
+}
+
+?>
+-----
+<?php
+
+class SomeClass
+{
+    #[\Neos\Flow\Annotations\Inject]
+    protected \Neos\Neos\Domain\Service\RenderingModeService $renderingModeService;
+    public function run(\Neos\Rector\ContentRepository90\Legacy\NodeLegacyStub $node)
+    {
+        $context = $node->getContext();
+        $renderingMode = $this->renderingModeService->findByCurrentUser();
+    }
+}
+
+?>

--- a/tests/ContentRepository90/Rules/ContextGetCurrentRenderingModeRector/Fixture/some_class3.php.inc
+++ b/tests/ContentRepository90/Rules/ContextGetCurrentRenderingModeRector/Fixture/some_class3.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+class SomeClass
+{
+    public function run(\Neos\Rector\ContentRepository90\Legacy\NodeLegacyStub $node)
+    {
+        $renderingMode = $node->getContext()->getCurrentRenderingMode();
+    }
+}
+
+?>
+-----
+<?php
+
+class SomeClass
+{
+    #[\Neos\Flow\Annotations\Inject]
+    protected \Neos\Neos\Domain\Service\RenderingModeService $renderingModeService;
+    public function run(\Neos\Rector\ContentRepository90\Legacy\NodeLegacyStub $node)
+    {
+        $renderingMode = $this->renderingModeService->findByCurrentUser();
+    }
+}
+
+?>

--- a/tests/ContentRepository90/Rules/ContextGetCurrentRenderingModeRector/config/configured_rule.php
+++ b/tests/ContentRepository90/Rules/ContextGetCurrentRenderingModeRector/config/configured_rule.php
@@ -1,0 +1,16 @@
+<?php
+
+declare (strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Neos\Rector\Generic\Rules\InjectServiceIfNeededRector;
+use Neos\Rector\Generic\ValueObject\AddInjection;
+use Neos\Neos\Domain\Service\RenderingModeService;
+
+return static function (RectorConfig $rectorConfig) : void {
+    $rectorConfig->rule(\Neos\Rector\ContentRepository90\Rules\ContextGetCurrentRenderingModeRector::class);
+
+    $rectorConfig->ruleWithConfiguration(InjectServiceIfNeededRector::class, [
+        new AddInjection('renderingModeService', RenderingModeService::class)
+    ]);
+};

--- a/tests/ContentRepository90/Rules/ContextIsInBackendRector/ContextIsInBackendTest.php
+++ b/tests/ContentRepository90/Rules/ContextIsInBackendRector/ContextIsInBackendTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\Rector\Tests\ContentRepository90\Rules\ContextGetFirstLevelNodeCacheRector;
+
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class ContextIsInBackendTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(string $fileInfo): void
+    {
+        $this->doTestFile($fileInfo);
+    }
+
+    /**
+     * @return \Iterator<string>
+     */
+    public function provideData(): \Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/ContentRepository90/Rules/ContextIsInBackendRector/Fixture/some_class.php.inc
+++ b/tests/ContentRepository90/Rules/ContextIsInBackendRector/Fixture/some_class.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+class SomeClass
+{
+    public function run(\Neos\Rector\ContentRepository90\Legacy\LegacyContextStub $context)
+    {
+        $isInBackend = $context->isInBackend();
+        if ($context->isInBackend() && $foo == 'bar') {
+            return true;
+        }
+    }
+}
+
+?>
+-----
+<?php
+
+class SomeClass
+{
+    #[\Neos\Flow\Annotations\Inject]
+    protected \Neos\Neos\Domain\Service\RenderingModeService $renderingModeService;
+    public function run(\Neos\Rector\ContentRepository90\Legacy\LegacyContextStub $context)
+    {
+        $isInBackend = $this->renderingModeService->findByCurrentUser()->isEdit;
+        if ($this->renderingModeService->findByCurrentUser()->isEdit && $foo == 'bar') {
+            return true;
+        }
+    }
+}
+
+?>

--- a/tests/ContentRepository90/Rules/ContextIsInBackendRector/Fixture/some_class2.php.inc
+++ b/tests/ContentRepository90/Rules/ContextIsInBackendRector/Fixture/some_class2.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+class SomeClass
+{
+    public function run(\Neos\Rector\ContentRepository90\Legacy\NodeLegacyStub $node)
+    {
+        $context = $node->getContext();
+        $isInBackend = $context->isInBackend();
+    }
+}
+
+?>
+-----
+<?php
+
+class SomeClass
+{
+    #[\Neos\Flow\Annotations\Inject]
+    protected \Neos\Neos\Domain\Service\RenderingModeService $renderingModeService;
+    public function run(\Neos\Rector\ContentRepository90\Legacy\NodeLegacyStub $node)
+    {
+        $context = $node->getContext();
+        $isInBackend = $this->renderingModeService->findByCurrentUser()->isEdit;
+    }
+}
+
+?>

--- a/tests/ContentRepository90/Rules/ContextIsInBackendRector/Fixture/some_class3.php.inc
+++ b/tests/ContentRepository90/Rules/ContextIsInBackendRector/Fixture/some_class3.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+use Neos\ContentRepository\Domain\Model\NodeInterface;
+
+class SomeClass
+{
+    public function run(\Neos\Rector\ContentRepository90\Legacy\NodeLegacyStub $node)
+    {
+        if ($node->getContext()->isInBackend() && $foo == 'bar') {
+            return true;
+        }
+    }
+}
+
+?>
+-----
+<?php
+
+use Neos\ContentRepository\Domain\Model\NodeInterface;
+
+class SomeClass
+{
+    #[\Neos\Flow\Annotations\Inject]
+    protected \Neos\Neos\Domain\Service\RenderingModeService $renderingModeService;
+    public function run(\Neos\Rector\ContentRepository90\Legacy\NodeLegacyStub $node)
+    {
+        if ($this->renderingModeService->findByCurrentUser()->isEdit && $foo == 'bar') {
+            return true;
+        }
+    }
+}
+
+?>

--- a/tests/ContentRepository90/Rules/ContextIsInBackendRector/config/configured_rule.php
+++ b/tests/ContentRepository90/Rules/ContextIsInBackendRector/config/configured_rule.php
@@ -1,0 +1,16 @@
+<?php
+
+declare (strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Neos\Rector\Generic\Rules\InjectServiceIfNeededRector;
+use Neos\Rector\Generic\ValueObject\AddInjection;
+use Neos\Neos\Domain\Service\RenderingModeService;
+
+return static function (RectorConfig $rectorConfig) : void {
+    $rectorConfig->rule(\Neos\Rector\ContentRepository90\Rules\ContextIsInBackendRector::class);
+
+    $rectorConfig->ruleWithConfiguration(InjectServiceIfNeededRector::class, [
+        new AddInjection('renderingModeService', RenderingModeService::class)
+    ]);
+};

--- a/tests/ContentRepository90/Rules/ContextIsLiveRector/ContextIsLiveTest.php
+++ b/tests/ContentRepository90/Rules/ContextIsLiveRector/ContextIsLiveTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\Rector\Tests\ContentRepository90\Rules\ContextGetFirstLevelNodeCacheRector;
+
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class ContextIsLiveTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(string $fileInfo): void
+    {
+        $this->doTestFile($fileInfo);
+    }
+
+    /**
+     * @return \Iterator<string>
+     */
+    public function provideData(): \Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/ContentRepository90/Rules/ContextIsLiveRector/Fixture/some_class.php.inc
+++ b/tests/ContentRepository90/Rules/ContextIsLiveRector/Fixture/some_class.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+class SomeClass
+{
+    public function run(\Neos\Rector\ContentRepository90\Legacy\LegacyContextStub $context)
+    {
+        $isLive = $context->isLive();
+        if ($context->isLive() && $foo == 'bar') {
+            return true;
+        }
+    }
+}
+
+?>
+-----
+<?php
+
+class SomeClass
+{
+    #[\Neos\Flow\Annotations\Inject]
+    protected \Neos\Neos\Domain\Service\RenderingModeService $renderingModeService;
+    public function run(\Neos\Rector\ContentRepository90\Legacy\LegacyContextStub $context)
+    {
+        $isLive = !$this->renderingModeService->findByCurrentUser()->isEdit && !$this->renderingModeService->findByCurrentUser()->isPreview;
+        if (!$this->renderingModeService->findByCurrentUser()->isEdit && !$this->renderingModeService->findByCurrentUser()->isPreview && $foo == 'bar') {
+            return true;
+        }
+    }
+}
+
+?>

--- a/tests/ContentRepository90/Rules/ContextIsLiveRector/Fixture/some_class2.php.inc
+++ b/tests/ContentRepository90/Rules/ContextIsLiveRector/Fixture/some_class2.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+class SomeClass
+{
+    public function run(\Neos\Rector\ContentRepository90\Legacy\NodeLegacyStub $node)
+    {
+        $context = $node->getContext();
+        $isLive = $context->isLive();
+    }
+}
+
+?>
+-----
+<?php
+
+class SomeClass
+{
+    #[\Neos\Flow\Annotations\Inject]
+    protected \Neos\Neos\Domain\Service\RenderingModeService $renderingModeService;
+    public function run(\Neos\Rector\ContentRepository90\Legacy\NodeLegacyStub $node)
+    {
+        $context = $node->getContext();
+        $isLive = !$this->renderingModeService->findByCurrentUser()->isEdit && !$this->renderingModeService->findByCurrentUser()->isPreview;
+    }
+}
+
+?>

--- a/tests/ContentRepository90/Rules/ContextIsLiveRector/Fixture/some_class3.php.inc
+++ b/tests/ContentRepository90/Rules/ContextIsLiveRector/Fixture/some_class3.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+use Neos\ContentRepository\Domain\Model\NodeInterface;
+
+class SomeClass
+{
+    public function run(\Neos\Rector\ContentRepository90\Legacy\NodeLegacyStub $node)
+    {
+        if ($node->getContext()->isLive() && $foo == 'bar') {
+            return true;
+        }
+    }
+}
+
+?>
+-----
+<?php
+
+use Neos\ContentRepository\Domain\Model\NodeInterface;
+
+class SomeClass
+{
+    #[\Neos\Flow\Annotations\Inject]
+    protected \Neos\Neos\Domain\Service\RenderingModeService $renderingModeService;
+    public function run(\Neos\Rector\ContentRepository90\Legacy\NodeLegacyStub $node)
+    {
+        if (!$this->renderingModeService->findByCurrentUser()->isEdit && !$this->renderingModeService->findByCurrentUser()->isPreview && $foo == 'bar') {
+            return true;
+        }
+    }
+}
+
+?>

--- a/tests/ContentRepository90/Rules/ContextIsLiveRector/config/configured_rule.php
+++ b/tests/ContentRepository90/Rules/ContextIsLiveRector/config/configured_rule.php
@@ -1,0 +1,16 @@
+<?php
+
+declare (strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Neos\Rector\Generic\Rules\InjectServiceIfNeededRector;
+use Neos\Rector\Generic\ValueObject\AddInjection;
+use Neos\Neos\Domain\Service\RenderingModeService;
+
+return static function (RectorConfig $rectorConfig) : void {
+    $rectorConfig->rule(\Neos\Rector\ContentRepository90\Rules\ContextIsLiveRector::class);
+
+    $rectorConfig->ruleWithConfiguration(InjectServiceIfNeededRector::class, [
+        new AddInjection('renderingModeService', RenderingModeService::class)
+    ]);
+};

--- a/tests/ContentRepository90/Rules/NodeFindParentNodeRector/Fixture/some_class.php.inc
+++ b/tests/ContentRepository90/Rules/NodeFindParentNodeRector/Fixture/some_class.php.inc
@@ -1,10 +1,10 @@
 <?php
 
-use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
+use Neos\Rector\ContentRepository90\Legacy\NodeLegacyStub;
 
 class SomeClass
 {
-    public function run(Node $node)
+    public function run(NodeLegacyStub $node)
     {
         $parentNode = $node->findParentNode();
     }
@@ -14,11 +14,11 @@ class SomeClass
 -----
 <?php
 
-use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
+use Neos\Rector\ContentRepository90\Legacy\NodeLegacyStub;
 
 class SomeClass
 {
-    public function run(Node $node)
+    public function run(NodeLegacyStub $node)
     {
         $subgraph = $this->contentRepositoryRegistry->subgraphForNode($node);
         $parentNode = $subgraph->findParentNode($node->nodeAggregateId);

--- a/tests/ContentRepository90/Rules/NodeGetDepthRector/Fixture/some_class.php.inc
+++ b/tests/ContentRepository90/Rules/NodeGetDepthRector/Fixture/some_class.php.inc
@@ -1,10 +1,10 @@
 <?php
 
-use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
+use Neos\Rector\ContentRepository90\Legacy\NodeLegacyStub;
 
 class SomeClass
 {
-    public function run(Node $node)
+    public function run(NodeLegacyStub $node)
     {
         return $node->getDepth();
     }
@@ -14,11 +14,11 @@ class SomeClass
 -----
 <?php
 
-use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
+use Neos\Rector\ContentRepository90\Legacy\NodeLegacyStub;
 
 class SomeClass
 {
-    public function run(Node $node)
+    public function run(NodeLegacyStub $node)
     {
         $subgraph = $this->contentRepositoryRegistry->subgraphForNode($node);
         return $subgraph->findNodePath($node->nodeAggregateId)->getDepth();

--- a/tests/ContentRepository90/Rules/NodeGetIdentifierRector/Fixture/some_class.php.inc
+++ b/tests/ContentRepository90/Rules/NodeGetIdentifierRector/Fixture/some_class.php.inc
@@ -1,10 +1,10 @@
 <?php
 
-use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
+use Neos\Rector\ContentRepository90\Legacy\NodeLegacyStub;
 
 class SomeClass
 {
-    public function run(Node $node)
+    public function run(NodeLegacyStub $node)
     {
         $nodeIdentifier = $node->getIdentifier();
     }
@@ -14,11 +14,11 @@ class SomeClass
 -----
 <?php
 
-use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
+use Neos\Rector\ContentRepository90\Legacy\NodeLegacyStub;
 
 class SomeClass
 {
-    public function run(Node $node)
+    public function run(NodeLegacyStub $node)
     {
         // TODO 9.0 migration: Check if you could change your code to work with the NodeAggregateId value object instead.
 

--- a/tests/ContentRepository90/Rules/NodeGetParentRector/Fixture/some_class.php.inc
+++ b/tests/ContentRepository90/Rules/NodeGetParentRector/Fixture/some_class.php.inc
@@ -1,10 +1,10 @@
 <?php
 
-use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
+use Neos\Rector\ContentRepository90\Legacy\NodeLegacyStub;
 
 class SomeClass
 {
-    public function run(Node $node)
+    public function run(NodeLegacyStub $node)
     {
         return $node->getParent();
     }
@@ -14,11 +14,11 @@ class SomeClass
 -----
 <?php
 
-use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
+use Neos\Rector\ContentRepository90\Legacy\NodeLegacyStub;
 
 class SomeClass
 {
-    public function run(Node $node)
+    public function run(NodeLegacyStub $node)
     {
         $subgraph = $this->contentRepositoryRegistry->subgraphForNode($node);
         return $subgraph->findParentNode($node->nodeAggregateId);

--- a/tests/ContentRepository90/Rules/NodeIsHiddenInIndexRector/Fixture/some_class.php.inc
+++ b/tests/ContentRepository90/Rules/NodeIsHiddenInIndexRector/Fixture/some_class.php.inc
@@ -1,10 +1,10 @@
 <?php
 
-use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
+use Neos\Rector\ContentRepository90\Legacy\NodeLegacyStub;
 
 class SomeClass
 {
-    public function run(Node $node)
+    public function run(NodeLegacyStub $node)
     {
         return $node->isHiddenInIndex();
     }
@@ -14,11 +14,11 @@ class SomeClass
 -----
 <?php
 
-use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
+use Neos\Rector\ContentRepository90\Legacy\NodeLegacyStub;
 
 class SomeClass
 {
-    public function run(Node $node)
+    public function run(NodeLegacyStub $node)
     {
         return $node->getProperty('_hiddenInIndex');
     }

--- a/tests/Generic/Rules/InjectServiceIfNeededRector/Fixture/has_already_content_repository_registry.php.inc
+++ b/tests/Generic/Rules/InjectServiceIfNeededRector/Fixture/has_already_content_repository_registry.php.inc
@@ -1,13 +1,13 @@
 <?php
 
-use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
+use Neos\Rector\ContentRepository90\Legacy\NodeLegacyStub;
 
 class SomeClass
 {
     #[\Neos\Flow\Annotations\Inject]
     protected \Neos\ContentRepositoryRegistry\ContentRepositoryRegistry $contentRepositoryRegistry;
 
-    public function run(Node $node)
+    public function run(NodeLegacyStub $node)
     {
         $subgraph = $this->contentRepositoryRegistry->subgraphForNode($node);
     }
@@ -17,14 +17,14 @@ class SomeClass
 -----
 <?php
 
-use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
+use Neos\Rector\ContentRepository90\Legacy\NodeLegacyStub;
 
 class SomeClass
 {
     #[\Neos\Flow\Annotations\Inject]
     protected \Neos\ContentRepositoryRegistry\ContentRepositoryRegistry $contentRepositoryRegistry;
 
-    public function run(Node $node)
+    public function run(NodeLegacyStub $node)
     {
         $subgraph = $this->contentRepositoryRegistry->subgraphForNode($node);
     }

--- a/tests/Generic/Rules/InjectServiceIfNeededRector/Fixture/needs_both.php.inc
+++ b/tests/Generic/Rules/InjectServiceIfNeededRector/Fixture/needs_both.php.inc
@@ -1,10 +1,10 @@
 <?php
 
-use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
+use Neos\Rector\ContentRepository90\Legacy\NodeLegacyStub;
 
 class SomeClass
 {
-    public function run(Node $node)
+    public function run(NodeLegacyStub $node)
     {
         $subgraph = $this->contentRepositoryRegistry->subgraphForNode($node);
         $currentRenderingMode = $this->renderingModeService->findByCurrentUser();
@@ -15,7 +15,7 @@ class SomeClass
 -----
 <?php
 
-use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
+use Neos\Rector\ContentRepository90\Legacy\NodeLegacyStub;
 
 class SomeClass
 {
@@ -23,7 +23,7 @@ class SomeClass
     protected \Neos\ContentRepositoryRegistry\ContentRepositoryRegistry $contentRepositoryRegistry;
     #[\Neos\Flow\Annotations\Inject]
     protected \Neos\Neos\Domain\Service\RenderingModeService $renderingModeService;
-    public function run(Node $node)
+    public function run(NodeLegacyStub $node)
     {
         $subgraph = $this->contentRepositoryRegistry->subgraphForNode($node);
         $currentRenderingMode = $this->renderingModeService->findByCurrentUser();

--- a/tests/Generic/Rules/InjectServiceIfNeededRector/Fixture/needs_content_repository_registry.php.inc
+++ b/tests/Generic/Rules/InjectServiceIfNeededRector/Fixture/needs_content_repository_registry.php.inc
@@ -1,10 +1,10 @@
 <?php
 
-use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
+use Neos\Rector\ContentRepository90\Legacy\NodeLegacyStub;
 
 class SomeClass
 {
-    public function run(Node $node)
+    public function run(NodeLegacyStub $node)
     {
         $subgraph = $this->contentRepositoryRegistry->subgraphForNode($node);
     }
@@ -14,13 +14,13 @@ class SomeClass
 -----
 <?php
 
-use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
+use Neos\Rector\ContentRepository90\Legacy\NodeLegacyStub;
 
 class SomeClass
 {
     #[\Neos\Flow\Annotations\Inject]
     protected \Neos\ContentRepositoryRegistry\ContentRepositoryRegistry $contentRepositoryRegistry;
-    public function run(Node $node)
+    public function run(NodeLegacyStub $node)
     {
         $subgraph = $this->contentRepositoryRegistry->subgraphForNode($node);
     }

--- a/tests/Rules/MethodCallToWarningCommentRector/Fixture/some_class.php.inc
+++ b/tests/Rules/MethodCallToWarningCommentRector/Fixture/some_class.php.inc
@@ -1,10 +1,10 @@
 <?php
 
-use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
+use Neos\Rector\ContentRepository90\Legacy\NodeLegacyStub;
 
 class SomeClass
 {
-    public function run(Node $node)
+    public function run(NodeLegacyStub $node)
     {
         return $node->getWorkspace();
     }
@@ -14,11 +14,11 @@ class SomeClass
 -----
 <?php
 
-use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
+use Neos\Rector\ContentRepository90\Legacy\NodeLegacyStub;
 
 class SomeClass
 {
-    public function run(Node $node)
+    public function run(NodeLegacyStub $node)
     {
         // TODO 9.0 migration: !! Node::getWorkspace() does not make sense anymore concept-wise. In Neos < 9, it pointed to the workspace where the node was *at home at*. Now, the closest we have here is the node identity.
 

--- a/tests/Rules/MethodCallToWarningCommentRector/config/configured_rule.php
+++ b/tests/Rules/MethodCallToWarningCommentRector/config/configured_rule.php
@@ -2,12 +2,12 @@
 
 declare (strict_types=1);
 
-use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
+use Neos\Rector\ContentRepository90\Legacy\NodeLegacyStub;
 use Neos\Rector\Generic\Rules\MethodCallToWarningCommentRector;
 use Neos\Rector\Generic\ValueObject\MethodCallToWarningComment;
 use Rector\Config\RectorConfig;
 return static function (RectorConfig $rectorConfig) : void {
     $rectorConfig->ruleWithConfiguration(MethodCallToWarningCommentRector::class, [
-        new MethodCallToWarningComment(Node::class, 'getWorkspace', '!! Node::getWorkspace() does not make sense anymore concept-wise. In Neos < 9, it pointed to the workspace where the node was *at home at*. Now, the closest we have here is the node identity.')
+        new MethodCallToWarningComment(NodeLegacyStub::class, 'getWorkspace', '!! Node::getWorkspace() does not make sense anymore concept-wise. In Neos < 9, it pointed to the workspace where the node was *at home at*. Now, the closest we have here is the node identity.')
     ]);
 };

--- a/tests/Rules/NodeGetChildNodesRector/Fixture/all-with-pagination-named-arguments.php.inc
+++ b/tests/Rules/NodeGetChildNodesRector/Fixture/all-with-pagination-named-arguments.php.inc
@@ -1,10 +1,10 @@
 <?php
 
-use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
+use Neos\Rector\ContentRepository90\Legacy\NodeLegacyStub;
 
 class SomeClass
 {
-    public function run(Node $node)
+    public function run(NodeLegacyStub $node)
     {
         foreach ($node->getChildNodes(offset: 100, limit: 10) as $node) {
         }
@@ -15,11 +15,11 @@ class SomeClass
 -----
 <?php
 
-use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
+use Neos\Rector\ContentRepository90\Legacy\NodeLegacyStub;
 
 class SomeClass
 {
-    public function run(Node $node)
+    public function run(NodeLegacyStub $node)
     {
         $subgraph = $this->contentRepositoryRegistry->subgraphForNode($node);
         // TODO 9.0 migration: Try to remove the iterator_to_array($nodes) call.

--- a/tests/Rules/NodeGetChildNodesRector/Fixture/all-with-pagination.php.inc
+++ b/tests/Rules/NodeGetChildNodesRector/Fixture/all-with-pagination.php.inc
@@ -1,10 +1,10 @@
 <?php
 
-use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
+use Neos\Rector\ContentRepository90\Legacy\NodeLegacyStub;
 
 class SomeClass
 {
-    public function run(Node $node)
+    public function run(NodeLegacyStub $node)
     {
         foreach ($node->getChildNodes(null, 10,100) as $node) {
         }
@@ -15,11 +15,11 @@ class SomeClass
 -----
 <?php
 
-use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
+use Neos\Rector\ContentRepository90\Legacy\NodeLegacyStub;
 
 class SomeClass
 {
-    public function run(Node $node)
+    public function run(NodeLegacyStub $node)
     {
         $subgraph = $this->contentRepositoryRegistry->subgraphForNode($node);
         // TODO 9.0 migration: Try to remove the iterator_to_array($nodes) call.

--- a/tests/Rules/NodeGetChildNodesRector/Fixture/all.php.inc
+++ b/tests/Rules/NodeGetChildNodesRector/Fixture/all.php.inc
@@ -1,10 +1,10 @@
 <?php
 
-use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
+use Neos\Rector\ContentRepository90\Legacy\NodeLegacyStub;
 
 class SomeClass
 {
-    public function run(Node $node)
+    public function run(NodeLegacyStub $node)
     {
         foreach ($node->getChildNodes() as $node) {
         }
@@ -15,11 +15,11 @@ class SomeClass
 -----
 <?php
 
-use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
+use Neos\Rector\ContentRepository90\Legacy\NodeLegacyStub;
 
 class SomeClass
 {
-    public function run(Node $node)
+    public function run(NodeLegacyStub $node)
     {
         $subgraph = $this->contentRepositoryRegistry->subgraphForNode($node);
         // TODO 9.0 migration: Try to remove the iterator_to_array($nodes) call.

--- a/tests/Rules/NodeGetChildNodesRector/Fixture/nodetype-filter-with-pagination.php.inc
+++ b/tests/Rules/NodeGetChildNodesRector/Fixture/nodetype-filter-with-pagination.php.inc
@@ -1,10 +1,10 @@
 <?php
 
-use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
+use Neos\Rector\ContentRepository90\Legacy\NodeLegacyStub;
 
 class SomeClass
 {
-    public function run(Node $node)
+    public function run(NodeLegacyStub $node)
     {
         foreach ($node->getChildNodes('Neos.Neos:Document', 10, 100) as $node) {
         }
@@ -15,11 +15,11 @@ class SomeClass
 -----
 <?php
 
-use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
+use Neos\Rector\ContentRepository90\Legacy\NodeLegacyStub;
 
 class SomeClass
 {
-    public function run(Node $node)
+    public function run(NodeLegacyStub $node)
     {
         $subgraph = $this->contentRepositoryRegistry->subgraphForNode($node);
         // TODO 9.0 migration: Try to remove the iterator_to_array($nodes) call.

--- a/tests/Rules/NodeGetChildNodesRector/Fixture/nodetype-filter.php.inc
+++ b/tests/Rules/NodeGetChildNodesRector/Fixture/nodetype-filter.php.inc
@@ -1,10 +1,10 @@
 <?php
 
-use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
+use Neos\Rector\ContentRepository90\Legacy\NodeLegacyStub;
 
 class SomeClass
 {
-    public function run(Node $node)
+    public function run(NodeLegacyStub $node)
     {
         foreach ($node->getChildNodes('Neos.Neos:Document') as $node) {
         }
@@ -15,11 +15,11 @@ class SomeClass
 -----
 <?php
 
-use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
+use Neos\Rector\ContentRepository90\Legacy\NodeLegacyStub;
 
 class SomeClass
 {
-    public function run(Node $node)
+    public function run(NodeLegacyStub $node)
     {
         $subgraph = $this->contentRepositoryRegistry->subgraphForNode($node);
         // TODO 9.0 migration: Try to remove the iterator_to_array($nodes) call.

--- a/tests/Rules/NodeGetContextGetWorkspaceNameRector/Fixture/some_class.php.inc
+++ b/tests/Rules/NodeGetContextGetWorkspaceNameRector/Fixture/some_class.php.inc
@@ -1,10 +1,10 @@
 <?php
 
-use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
+use Neos\Rector\ContentRepository90\Legacy\NodeLegacyStub;
 
 class SomeClass
 {
-    public function run(Node $node)
+    public function run(NodeLegacyStub $node)
     {
         return $node->getContext()->getWorkspaceName();
     }
@@ -14,11 +14,11 @@ class SomeClass
 -----
 <?php
 
-use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
+use Neos\Rector\ContentRepository90\Legacy\NodeLegacyStub;
 
 class SomeClass
 {
-    public function run(Node $node)
+    public function run(NodeLegacyStub $node)
     {
         $contentRepository = $this->contentRepositoryRegistry->get($node->subgraphIdentity->contentRepositoryId);
         return $contentRepository->getWorkspaceFinder()->findOneByCurrentContentStreamId($node->subgraphIdentity->contentStreamId)->workspaceName;

--- a/tests/Rules/NodeGetContextGetWorkspaceRector/Fixture/some_class.php.inc
+++ b/tests/Rules/NodeGetContextGetWorkspaceRector/Fixture/some_class.php.inc
@@ -1,10 +1,10 @@
 <?php
 
-use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
+use Neos\Rector\ContentRepository90\Legacy\NodeLegacyStub;
 
 class SomeClass
 {
-    public function run(Node $node)
+    public function run(NodeLegacyStub $node)
     {
         return $node->getContext()->getWorkspace();
     }
@@ -14,11 +14,11 @@ class SomeClass
 -----
 <?php
 
-use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
+use Neos\Rector\ContentRepository90\Legacy\NodeLegacyStub;
 
 class SomeClass
 {
-    public function run(Node $node)
+    public function run(NodeLegacyStub $node)
     {
         $contentRepository = $this->contentRepositoryRegistry->get($node->subgraphIdentity->contentRepositoryId);
         return $contentRepository->getWorkspaceFinder()->findOneByCurrentContentStreamId($node->subgraphIdentity->contentStreamId);

--- a/tests/Rules/NodeGetDimensionsRector/Fixture/some_class.php.inc
+++ b/tests/Rules/NodeGetDimensionsRector/Fixture/some_class.php.inc
@@ -1,10 +1,10 @@
 <?php
 
-use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
+use Neos\Rector\ContentRepository90\Legacy\NodeLegacyStub;
 
 class SomeClass
 {
-    public function run(Node $node)
+    public function run(NodeLegacyStub $node)
     {
         return $node->getDimensions();
     }
@@ -14,11 +14,11 @@ class SomeClass
 -----
 <?php
 
-use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
+use Neos\Rector\ContentRepository90\Legacy\NodeLegacyStub;
 
 class SomeClass
 {
-    public function run(Node $node)
+    public function run(NodeLegacyStub $node)
     {
         // TODO 9.0 migration: Try to remove the toLegacyDimensionArray() call and make your codebase more typesafe.
 

--- a/tests/Rules/NodeGetPathRector/Fixture/some_class.php.inc
+++ b/tests/Rules/NodeGetPathRector/Fixture/some_class.php.inc
@@ -1,10 +1,10 @@
 <?php
 
-use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
+use Neos\Rector\ContentRepository90\Legacy\NodeLegacyStub;
 
 class SomeClass
 {
-    public function run(Node $node)
+    public function run(NodeLegacyStub $node)
     {
         return $node->getPath();
     }
@@ -14,11 +14,11 @@ class SomeClass
 -----
 <?php
 
-use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
+use Neos\Rector\ContentRepository90\Legacy\NodeLegacyStub;
 
 class SomeClass
 {
-    public function run(Node $node)
+    public function run(NodeLegacyStub $node)
     {
         $subgraph = $this->contentRepositoryRegistry->subgraphForNode($node);
         // TODO 9.0 migration: Try to remove the (string) cast and make your code more type-safe.

--- a/tests/Rules/NodeIsHiddenRector/Fixture/some_class.php.inc
+++ b/tests/Rules/NodeIsHiddenRector/Fixture/some_class.php.inc
@@ -1,10 +1,10 @@
 <?php
 
-use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
+use Neos\Rector\ContentRepository90\Legacy\NodeLegacyStub;
 
 class SomeClass
 {
-    public function run(Node $node)
+    public function run(NodeLegacyStub $node)
     {
         return $node->isHidden();
     }
@@ -14,11 +14,11 @@ class SomeClass
 -----
 <?php
 
-use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
+use Neos\Rector\ContentRepository90\Legacy\NodeLegacyStub;
 
 class SomeClass
 {
-    public function run(Node $node)
+    public function run(NodeLegacyStub $node)
     {
         $contentRepository = $this->contentRepositoryRegistry->get($node->subgraphIdentity->contentRepositoryId);
         $nodeHiddenStateFinder = $contentRepository->projectionState(\Neos\ContentRepository\Core\Projection\NodeHiddenState\NodeHiddenStateFinder::class);


### PR DESCRIPTION
This rector replaces removed ContentContext calls in PHP and Fusion. For better detection of context objects all Node(Interface)s get replaced by `Neos\Rector\ContentRepository90\Legacy\NodeLegacyStub`. The `Neos\Rector\ContentRepository90\Legacy\NodeLegacyStub` get replaced at the end by `Neos\ContentRepository\Core\Projection\ContentGraph\Node`

PHP
* `ContentContext::isInBackend` => `$this->renderingModeService->findByCurrentUser()->isEdit`
* `ContentContext::isLive` => `!$this->renderingModeService->findByCurrentUser()->isEdit && !$this->renderingModeService->findByCurrentUser()->isPreview`
* `ContentContext::getCurrentRenderingMode` => `$this->renderingModeService->findByCurrentUser()`
* `ContentContext::getCurrentSiteNode` => Warning, no replacement
* `ContentContext::getCurrentDomain` => Warning, no replacement
* `ContentContext::getCurrentSite` => Warning, no replacement

Fusion
* `node.context.currentDomain` => Warning, no replacement
* `context.currentSiteNode` => Warning, no replacement

Fixes #31