### PR TITLE
TASK PrimaryContent removal

### DIFF
--- a/config/set/contentrepository-90.php
+++ b/config/set/contentrepository-90.php
@@ -50,6 +50,7 @@ use Neos\Rector\ContentRepository90\Rules\FusionNodeTypeNameRector;
 use Neos\Rector\ContentRepository90\Rules\NodeTypeGetNameRector;
 use Neos\Rector\Generic\ValueObject\AddInjection;
 use Neos\ContentRepositoryRegistry\ContentRepositoryRegistry;
+use Neos\Rector\ContentRepository90\Rules\FusionPrimaryContentRector;
 
 return static function (RectorConfig $rectorConfig): void {
     // Register FusionFileProcessor. All Fusion Rectors will be auto-registered at this processor.
@@ -318,6 +319,11 @@ return static function (RectorConfig $rectorConfig): void {
      * Neos\ContentRepository\Domain\Model\Workspace
      */
     $rectorConfig->rule(WorkspaceGetNameRector::class);
+
+    /**
+     * Neos.Neos:PrimaryContent
+     */
+    $rectorConfig->rule(FusionPrimaryContentRector::class );
 
     /**
      * SPECIAL rules

--- a/src/ContentRepository90/Rules/FusionPrimaryContentRector.php
+++ b/src/ContentRepository90/Rules/FusionPrimaryContentRector.php
@@ -16,10 +16,14 @@ class FusionPrimaryContentRector implements FusionRectorInterface
 
     public function refactorFileContent(string $fileContent): string
     {
-        return EelExpressionTransformer::parse($fileContent)
-            ->addCommentsIfRegexMatches(
-                '/Neos\.Neos:PrimaryContent/',
-                '// TODO 9.0 migration: Line %LINE: You need to rewrite "Neos.Neos:PrimaryContent" to "Neos.Neos:ContentCollection".'
-            )->getProcessedContent();
+        $comment = '// TODO 9.0 migration: You need to rewrite "Neos.Neos:PrimaryContent" to "Neos.Neos:ContentCollection".';
+        $regex = '/Neos\.Neos:PrimaryContent/';
+
+        if (preg_match($regex, $fileContent) === 1){
+            return $comment . "\n" . $fileContent;
+        }
+
+        return $fileContent;
+
     }
 }

--- a/src/ContentRepository90/Rules/FusionPrimaryContentRector.php
+++ b/src/ContentRepository90/Rules/FusionPrimaryContentRector.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+
+namespace Neos\Rector\ContentRepository90\Rules;
+
+use Neos\Rector\Core\FusionProcessing\EelExpressionTransformer;
+use Neos\Rector\Core\FusionProcessing\FusionRectorInterface;
+use Neos\Rector\Utility\CodeSampleLoader;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+class FusionPrimaryContentRector implements FusionRectorInterface
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return CodeSampleLoader::fromFile('Fusion: Warn about removed "Neos.Neos:PrimaryContent"', __CLASS__);
+    }
+
+    public function refactorFileContent(string $fileContent): string
+    {
+        return EelExpressionTransformer::parse($fileContent)
+            ->addCommentsIfRegexMatches(
+                '/Neos\.Neos:PrimaryContent/',
+                '// TODO 9.0 migration: Line %LINE: You need to rewrite "Neos.Neos:PrimaryContent" to "Neos.Neos:ContentCollection".'
+            )->getProcessedContent();
+    }
+}

--- a/tests/ContentRepository90/Rules/FusionPrimaryContentRector/Fixture/some_file.fusion.inc
+++ b/tests/ContentRepository90/Rules/FusionPrimaryContentRector/Fixture/some_file.fusion.inc
@@ -1,0 +1,27 @@
+prototype(My.Fancy:Component) < prototype(Neos.Fusion:Join) {
+  main = Neos.Neos:PrimaryContent {
+    nodePath = 'main'
+  }
+
+  content = Neos.Neos:PrimaryContent
+  content.nodePath = 'content'
+}
+
+prototype(My.Evil:Component) < prototype(Neos.Neos:PrimaryContent) {
+
+}
+-----
+// TODO 9.0 migration: Line 2: You need to rewrite "Neos.Neos:PrimaryContent" to "Neos.Neos:ContentCollection".
+// TODO 9.0 migration: Line 6: You need to rewrite "Neos.Neos:PrimaryContent" to "Neos.Neos:ContentCollection".
+prototype(My.Fancy:Component) < prototype(Neos.Fusion:Join) {
+  main = Neos.Neos:PrimaryContent {
+    nodePath = 'main'
+  }
+
+  content = Neos.Neos:PrimaryContent
+  content.nodePath = 'content'
+}
+// TODO 9.0 migration: Line 10: You need to rewrite "Neos.Neos:PrimaryContent" to "Neos.Neos:ContentCollection".
+prototype(My.Evil:Component) < prototype(Neos.Neos:PrimaryContent) {
+
+}

--- a/tests/ContentRepository90/Rules/FusionPrimaryContentRector/Fixture/some_file.fusion.inc
+++ b/tests/ContentRepository90/Rules/FusionPrimaryContentRector/Fixture/some_file.fusion.inc
@@ -11,7 +11,7 @@ prototype(My.Evil:Component) < prototype(Neos.Neos:PrimaryContent) {
 
 }
 -----
-// TODO 9.0 migration: You need to rewrite "Neos.Neos:PrimaryContent" to "Neos.Neos:ContentCollection".
+// TODO 9.0 migration: You need to refactor "Neos.Neos:PrimaryContent" to use "Neos.Neos:ContentCollection" instead.
 prototype(My.Fancy:Component) < prototype(Neos.Fusion:Join) {
   main = Neos.Neos:PrimaryContent {
     nodePath = 'main'

--- a/tests/ContentRepository90/Rules/FusionPrimaryContentRector/Fixture/some_file.fusion.inc
+++ b/tests/ContentRepository90/Rules/FusionPrimaryContentRector/Fixture/some_file.fusion.inc
@@ -11,8 +11,7 @@ prototype(My.Evil:Component) < prototype(Neos.Neos:PrimaryContent) {
 
 }
 -----
-// TODO 9.0 migration: Line 2: You need to rewrite "Neos.Neos:PrimaryContent" to "Neos.Neos:ContentCollection".
-// TODO 9.0 migration: Line 6: You need to rewrite "Neos.Neos:PrimaryContent" to "Neos.Neos:ContentCollection".
+// TODO 9.0 migration: You need to rewrite "Neos.Neos:PrimaryContent" to "Neos.Neos:ContentCollection".
 prototype(My.Fancy:Component) < prototype(Neos.Fusion:Join) {
   main = Neos.Neos:PrimaryContent {
     nodePath = 'main'
@@ -21,7 +20,7 @@ prototype(My.Fancy:Component) < prototype(Neos.Fusion:Join) {
   content = Neos.Neos:PrimaryContent
   content.nodePath = 'content'
 }
-// TODO 9.0 migration: Line 10: You need to rewrite "Neos.Neos:PrimaryContent" to "Neos.Neos:ContentCollection".
+
 prototype(My.Evil:Component) < prototype(Neos.Neos:PrimaryContent) {
 
 }

--- a/tests/ContentRepository90/Rules/FusionPrimaryContentRector/Fixture/some_file2.fusion.inc
+++ b/tests/ContentRepository90/Rules/FusionPrimaryContentRector/Fixture/some_file2.fusion.inc
@@ -2,7 +2,7 @@ prototype(My.Evil:Component) < prototype(Neos.Neos:PrimaryContent) {
 
 }
 -----
-// TODO 9.0 migration: You need to rewrite "Neos.Neos:PrimaryContent" to "Neos.Neos:ContentCollection".
+// TODO 9.0 migration: You need to refactor "Neos.Neos:PrimaryContent" to use "Neos.Neos:ContentCollection" instead.
 prototype(My.Evil:Component) < prototype(Neos.Neos:PrimaryContent) {
 
 }

--- a/tests/ContentRepository90/Rules/FusionPrimaryContentRector/Fixture/some_file2.fusion.inc
+++ b/tests/ContentRepository90/Rules/FusionPrimaryContentRector/Fixture/some_file2.fusion.inc
@@ -1,0 +1,8 @@
+prototype(My.Evil:Component) < prototype(Neos.Neos:PrimaryContent) {
+
+}
+-----
+// TODO 9.0 migration: You need to rewrite "Neos.Neos:PrimaryContent" to "Neos.Neos:ContentCollection".
+prototype(My.Evil:Component) < prototype(Neos.Neos:PrimaryContent) {
+
+}

--- a/tests/ContentRepository90/Rules/FusionPrimaryContentRector/FusionPrimaryContentRectorTest.php
+++ b/tests/ContentRepository90/Rules/FusionPrimaryContentRector/FusionPrimaryContentRectorTest.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types=1);
+
+namespace Neos\Rector\Tests\ContentRepository90\Rules\FusionPrimaryContentRector;
+
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class FusionPrimaryContentRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(string $fileInfo): void
+    {
+        $this->doTestFile($fileInfo);
+    }
+
+    /**
+     * @return \Iterator<string>
+     */
+    public function provideData(): \Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture', '*.fusion.inc');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/ContentRepository90/Rules/FusionPrimaryContentRector/config/configured_rule.php
+++ b/tests/ContentRepository90/Rules/FusionPrimaryContentRector/config/configured_rule.php
@@ -1,0 +1,16 @@
+<?php declare (strict_types=1);
+
+use Neos\Rector\ContentRepository90\Rules\FusionPrimaryContentRector;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig) : void {
+    $services = $rectorConfig->services();
+    $services->defaults()
+        ->public()
+        ->autowire()
+        ->autoconfigure();
+    $services->set(\Neos\Rector\Core\FusionProcessing\FusionFileProcessor::class);
+    $rectorConfig->disableParallel(); // does not work for fusion files - see https://github.com/rectorphp/rector-src/pull/2597#issuecomment-1190120688
+
+    $rectorConfig->rule(FusionPrimaryContentRector::class);
+};


### PR DESCRIPTION
Adds a warning to each Fusion file containing `Neos.Neos:PrimaryContent`

See: https://github.com/neos/neos-development-collection/pull/4281
See: https://github.com/neos/neos-development-collection/issues/4622