### PR TITLE
FEATURE: Migration for new fusion property access of timeable node visibility

### DIFF
--- a/config/set/contentrepository-90.php
+++ b/config/set/contentrepository-90.php
@@ -66,6 +66,8 @@ use Rector\Renaming\Rector\Name\RenameClassRector;
 use Rector\Renaming\ValueObject\MethodCallRename;
 use Rector\Transform\Rector\MethodCall\MethodCallToPropertyFetchRector;
 use Rector\Transform\ValueObject\MethodCallToPropertyFetch;
+use Neos\Rector\ContentRepository90\Rules\FusionNodeHiddenAfterDateTimeRector;
+use Neos\Rector\ContentRepository90\Rules\FusionNodeHiddenBeforeDateTimeRector;
 
 return static function (RectorConfig $rectorConfig): void {
     // Register FusionFileProcessor. All Fusion Rectors will be auto-registered at this processor.
@@ -139,14 +141,12 @@ return static function (RectorConfig $rectorConfig): void {
     $methodCallToWarningComments[] = new MethodCallToWarningComment(NodeLegacyStub::class, 'setHiddenBeforeDateTime', '!! Node::setHiddenBeforeDateTime() is not supported by the new CR. Timed publishing will be implemented not on the read model, but by dispatching commands at a given time.');
     // getHiddenBeforeDateTime
     $methodCallToWarningComments[] = new MethodCallToWarningComment(NodeLegacyStub::class, 'getHiddenBeforeDateTime', '!! Node::getHiddenBeforeDateTime() is not supported by the new CR. Timed publishing will be implemented not on the read model, but by dispatching commands at a given time.');
-    $fusionNodePropertyPathToWarningComments[] = new FusionNodePropertyPathToWarningComment('hiddenBeforeDateTime', 'Line %LINE: !! node.hiddenBeforeDateTime is not supported by the new CR. Timed publishing will be implemented not on the read model, but by dispatching commands at a given time.');
-    $fusionFlowQueryPropertyToComments[] = new FusionFlowQueryNodePropertyToWarningComment('_hiddenBeforeDateTime', 'Line %LINE: !! "q(VARIABLE).property("_hiddenBeforeDateTime")" is not supported by the new CR. Timed publishing will be implemented not on the read model, but by dispatching commands at a given time.');
+    $rectorConfig->rule(FusionNodeHiddenBeforeDateTimeRector::class);
     // setHiddenAfterDateTime
     $methodCallToWarningComments[] = new MethodCallToWarningComment(NodeLegacyStub::class, 'setHiddenAfterDateTime', '!! Node::setHiddenAfterDateTime() is not supported by the new CR. Timed publishing will be implemented not on the read model, but by dispatching commands at a given time.');
     // getHiddenAfterDateTime
     $methodCallToWarningComments[] = new MethodCallToWarningComment(NodeLegacyStub::class, 'getHiddenAfterDateTime', '!! Node::getHiddenAfterDateTime() is not supported by the new CR. Timed publishing will be implemented not on the read model, but by dispatching commands at a given time.');
-    $fusionNodePropertyPathToWarningComments[] = new FusionNodePropertyPathToWarningComment('hiddenAfterDateTime', 'Line %LINE: !! node.hiddenAfterDateTime is not supported by the new CR. Timed publishing will be implemented not on the read model, but by dispatching commands at a given time.');
-    $fusionFlowQueryPropertyToComments[] = new FusionFlowQueryNodePropertyToWarningComment('_hiddenAfterDateTime', 'Line %LINE: !! "q(VARIABLE).property("_hiddenAfterDateTime")" is not supported by the new CR. Timed publishing will be implemented not on the read model, but by dispatching commands at a given time.');
+    $rectorConfig->rule(FusionNodeHiddenAfterDateTimeRector::class);
     // setHiddenInIndex
     // isHiddenInIndex
     $rectorConfig->rule(NodeIsHiddenInIndexRector::class);

--- a/src/ContentRepository90/Rules/FusionNodeHiddenAfterDateTimeRector.php
+++ b/src/ContentRepository90/Rules/FusionNodeHiddenAfterDateTimeRector.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\Rector\ContentRepository90\Rules;
+
+use Neos\Rector\Core\FusionProcessing\EelExpressionTransformer;
+use Neos\Rector\Core\FusionProcessing\FusionRectorInterface;
+use Neos\Rector\Utility\CodeSampleLoader;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+class FusionNodeHiddenAfterDateTimeRector implements FusionRectorInterface
+{
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return CodeSampleLoader::fromFile('Fusion: Rewrite node.hiddenAfterDateTime to q(node).property("disableAfterDateTime")', __CLASS__);
+    }
+
+    public function refactorFileContent(string $fileContent): string
+    {
+        return EelExpressionTransformer::parse($fileContent)
+            ->process(fn(string $eelExpression) => preg_replace(
+                '/(node|documentNode)\.hiddenAfterDateTime/',
+                'q($1).property("disableAfterDateTime")',
+                $eelExpression
+            ))
+            ->process(fn(string $eelExpression) => preg_replace(
+                '/.property\(["\']_hiddenAfterDateTime["\']\)/',
+                '.property("disableAfterDateTime")',
+                $eelExpression
+            ))
+            ->addCommentsIfRegexMatches(
+                '/\.hiddenAfterDateTime/',
+                '// TODO 9.0 migration: Line %LINE: You may need to rewrite "VARIABLE.hiddenAfterDateTime" to q(VARIABLE).property("disableAfterDateTime"). We did not auto-apply this migration because we cannot be sure whether the variable is a Node.'
+            )->getProcessedContent();
+    }
+}

--- a/src/ContentRepository90/Rules/FusionNodeHiddenBeforeDateTimeRector.php
+++ b/src/ContentRepository90/Rules/FusionNodeHiddenBeforeDateTimeRector.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\Rector\ContentRepository90\Rules;
+
+use Neos\Rector\Core\FusionProcessing\EelExpressionTransformer;
+use Neos\Rector\Core\FusionProcessing\FusionRectorInterface;
+use Neos\Rector\Utility\CodeSampleLoader;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+class FusionNodeHiddenBeforeDateTimeRector implements FusionRectorInterface
+{
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return CodeSampleLoader::fromFile('Fusion: Rewrite node.hiddenBeforeDateTime to q(node).property("enableAfterDateTime")', __CLASS__);
+    }
+
+    public function refactorFileContent(string $fileContent): string
+    {
+        return EelExpressionTransformer::parse($fileContent)
+            ->process(fn(string $eelExpression) => preg_replace(
+                '/(node|documentNode)\.hiddenBeforeDateTime/',
+                'q($1).property("enableAfterDateTime")',
+                $eelExpression
+            ))
+            ->process(fn(string $eelExpression) => preg_replace(
+                '/.property\(["\']_hiddenBeforeDateTime["\']\)/',
+                '.property("enableAfterDateTime")',
+                $eelExpression
+            ))
+            ->addCommentsIfRegexMatches(
+                '/\.hiddenBeforeDateTime/',
+                '// TODO 9.0 migration: Line %LINE: You may need to rewrite "VARIABLE.hiddenBeforeDateTime" to q(VARIABLE).property("enableAfterDateTime"). We did not auto-apply this migration because we cannot be sure whether the variable is a Node.'
+            )->getProcessedContent();
+    }
+}

--- a/tests/ContentRepository90/Rules/FusionNodeHiddenAfterDateTimeRector/Fixture/some_file.fusion.inc
+++ b/tests/ContentRepository90/Rules/FusionNodeHiddenAfterDateTimeRector/Fixture/some_file.fusion.inc
@@ -1,0 +1,44 @@
+prototype(Neos.Fusion.Form:Checkbox)  < prototype(Neos.Fusion.Form:Component.Field) {
+
+  renderer = Neos.Fusion:Component {
+
+    #
+    # pass down props
+    #
+    attributes = ${node.hiddenAfterDateTime || documentNode.hiddenAfterDateTime}
+    attributes2 = ${q(node).property("_hiddenAfterDateTime")}
+
+    renderer = afx`
+      <input
+        type="checkbox"
+        name={node.hiddenAfterDateTime}
+        value={someOtherVariable.hiddenAfterDateTime}
+        checked={props.checked}
+        {...node.hiddenAfterDateTime}
+      />
+    `
+  }
+}
+-----
+// TODO 9.0 migration: Line 16: You may need to rewrite "VARIABLE.hiddenAfterDateTime" to q(VARIABLE).property("disableAfterDateTime"). We did not auto-apply this migration because we cannot be sure whether the variable is a Node.
+prototype(Neos.Fusion.Form:Checkbox)  < prototype(Neos.Fusion.Form:Component.Field) {
+
+  renderer = Neos.Fusion:Component {
+
+    #
+    # pass down props
+    #
+    attributes = ${q(node).property("disableAfterDateTime") || q(documentNode).property("disableAfterDateTime")}
+    attributes2 = ${q(node).property("disableAfterDateTime")}
+
+    renderer = afx`
+      <input
+        type="checkbox"
+        name={q(node).property("disableAfterDateTime")}
+        value={someOtherVariable.hiddenAfterDateTime}
+        checked={props.checked}
+        {...q(node).property("disableAfterDateTime")}
+      />
+    `
+  }
+}

--- a/tests/ContentRepository90/Rules/FusionNodeHiddenAfterDateTimeRector/FusionNodeHiddenAfterDateTimeRectorTest.php
+++ b/tests/ContentRepository90/Rules/FusionNodeHiddenAfterDateTimeRector/FusionNodeHiddenAfterDateTimeRectorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\Rector\Tests\ContentRepository90\Rules\FusionNodeHiddenInIndexRector;
+
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class FusionNodeHiddenAfterDateTimeRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(string $fileInfo): void
+    {
+        $this->doTestFile($fileInfo);
+    }
+
+    /**
+     * @return \Iterator<string>
+     */
+    public function provideData(): \Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture', '*.fusion.inc');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/ContentRepository90/Rules/FusionNodeHiddenAfterDateTimeRector/config/configured_rule.php
+++ b/tests/ContentRepository90/Rules/FusionNodeHiddenAfterDateTimeRector/config/configured_rule.php
@@ -1,0 +1,19 @@
+<?php
+
+declare (strict_types=1);
+
+use Neos\Rector\Core\FusionProcessing\FusionFileProcessor;
+use Rector\Config\RectorConfig;
+use Neos\Rector\ContentRepository90\Rules\FusionNodeHiddenAfterDateTimeRector;
+
+return static function (RectorConfig $rectorConfig) : void {
+    $services = $rectorConfig->services();
+    $services->defaults()
+        ->public()
+        ->autowire()
+        ->autoconfigure();
+    $services->set(FusionFileProcessor::class);
+    $rectorConfig->disableParallel(); // does not work for fusion files - see https://github.com/rectorphp/rector-src/pull/2597#issuecomment-1190120688
+
+    $rectorConfig->rule(FusionNodeHiddenAfterDateTimeRector::class);
+};

--- a/tests/ContentRepository90/Rules/FusionNodeHiddenBeforeDateTimeRector/Fixture/some_file.fusion.inc
+++ b/tests/ContentRepository90/Rules/FusionNodeHiddenBeforeDateTimeRector/Fixture/some_file.fusion.inc
@@ -1,0 +1,44 @@
+prototype(Neos.Fusion.Form:Checkbox)  < prototype(Neos.Fusion.Form:Component.Field) {
+
+  renderer = Neos.Fusion:Component {
+
+    #
+    # pass down props
+    #
+    attributes = ${node.hiddenBeforeDateTime || documentNode.hiddenBeforeDateTime}
+    attribute2 = ${q(node).property("_hiddenBeforeDateTime")}
+
+    renderer = afx`
+      <input
+        type="checkbox"
+        name={node.hiddenBeforeDateTime}
+        value={someOtherVariable.hiddenBeforeDateTime}
+        checked={props.checked}
+        {...node.hiddenBeforeDateTime}
+      />
+    `
+  }
+}
+-----
+// TODO 9.0 migration: Line 16: You may need to rewrite "VARIABLE.hiddenBeforeDateTime" to q(VARIABLE).property("enableAfterDateTime"). We did not auto-apply this migration because we cannot be sure whether the variable is a Node.
+prototype(Neos.Fusion.Form:Checkbox)  < prototype(Neos.Fusion.Form:Component.Field) {
+
+  renderer = Neos.Fusion:Component {
+
+    #
+    # pass down props
+    #
+    attributes = ${q(node).property("enableAfterDateTime") || q(documentNode).property("enableAfterDateTime")}
+    attribute2 = ${q(node).property("enableAfterDateTime")}
+
+    renderer = afx`
+      <input
+        type="checkbox"
+        name={q(node).property("enableAfterDateTime")}
+        value={someOtherVariable.hiddenBeforeDateTime}
+        checked={props.checked}
+        {...q(node).property("enableAfterDateTime")}
+      />
+    `
+  }
+}

--- a/tests/ContentRepository90/Rules/FusionNodeHiddenBeforeDateTimeRector/FusionNodeHiddenBeforeDateTimeRectorTest.php
+++ b/tests/ContentRepository90/Rules/FusionNodeHiddenBeforeDateTimeRector/FusionNodeHiddenBeforeDateTimeRectorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\Rector\Tests\ContentRepository90\Rules\FusionNodeHiddenInIndexRector;
+
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class FusionNodeHiddenBeforeDateTimeRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(string $fileInfo): void
+    {
+        $this->doTestFile($fileInfo);
+    }
+
+    /**
+     * @return \Iterator<string>
+     */
+    public function provideData(): \Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture', '*.fusion.inc');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/ContentRepository90/Rules/FusionNodeHiddenBeforeDateTimeRector/config/configured_rule.php
+++ b/tests/ContentRepository90/Rules/FusionNodeHiddenBeforeDateTimeRector/config/configured_rule.php
@@ -1,0 +1,19 @@
+<?php
+
+declare (strict_types=1);
+
+use Neos\Rector\Core\FusionProcessing\FusionFileProcessor;
+use Rector\Config\RectorConfig;
+use Neos\Rector\ContentRepository90\Rules\FusionNodeHiddenBeforeDateTimeRector;
+
+return static function (RectorConfig $rectorConfig) : void {
+    $services = $rectorConfig->services();
+    $services->defaults()
+        ->public()
+        ->autowire()
+        ->autoconfigure();
+    $services->set(FusionFileProcessor::class);
+    $rectorConfig->disableParallel(); // does not work for fusion files - see https://github.com/rectorphp/rector-src/pull/2597#issuecomment-1190120688
+
+    $rectorConfig->rule(FusionNodeHiddenBeforeDateTimeRector::class);
+};


### PR DESCRIPTION
Fusion: 
* Rewrite `node.hiddenBeforeDateTime` to `q(node).property("enableAfterDateTime")`
* Rewrite `q(node).property("_hiddenBeforeDateTime")` to `q(node).property("enableAfterDateTime")`
* Rewrite `node.hiddenAfterDateTime` to `q(node).property("disableAfterDateTime")`
* Rewrite `q(node).property("_hiddenAfterDateTime")` to `q(node).property("disableAfterDateTime")`

Fixes #41 