### PR TITLE
TASK: Migrate `${node.nodeType.name}` and `${node.nodeType}`

### DIFF
--- a/config/set/contentrepository-90.php
+++ b/config/set/contentrepository-90.php
@@ -25,6 +25,7 @@ use Neos\Rector\ContentRepository90\Rules\FusionNodeContextPathRector;
 use Neos\Rector\ContentRepository90\Rules\FusionNodeDepthRector;
 use Neos\Rector\ContentRepository90\Rules\FusionNodeHiddenInIndexRector;
 use Neos\Rector\ContentRepository90\Rules\FusionNodeIdentifierRector;
+use Neos\Rector\ContentRepository90\Rules\FusionNodeNodeTypeRector;
 use Neos\Rector\ContentRepository90\Rules\FusionNodeParentRector;
 use Neos\Rector\ContentRepository90\Rules\FusionNodePathRector;
 use Neos\Rector\ContentRepository90\Rules\FusionNodeTypeNameRector;
@@ -152,7 +153,9 @@ return static function (RectorConfig $rectorConfig): void {
     // setNodeType
     // getNodeType: NodeType
     $methodCallToPropertyFetches[] = new MethodCallToPropertyFetch(NodeLegacyStub::class, 'getNodeType', 'nodeType');
-    $fusionFlowQueryPropertyToComments[] = new FusionFlowQueryNodePropertyToWarningComment('_nodeType', 'Line %LINE: !! You very likely need to rewrite "q(VARIABLE).property("_nodeType")" to "VARIABLE.nodeType". We did not auto-apply this migration because we cannot be sure whether the variable is a Node.');
+    // Fusion: node.nodeType -> Neos.Node.getNodeType(node)
+    // Fusion: node.nodeType.name -> q(node).nodeTypeName()
+    $rectorConfig->rule(FusionNodeNodeTypeRector::class);
     // setHidden
     // isHidden
     $rectorConfig->rule(NodeIsHiddenRector::class);

--- a/src/ContentRepository90/Rules/FusionNodeNodeTypeRector.php
+++ b/src/ContentRepository90/Rules/FusionNodeNodeTypeRector.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\Rector\ContentRepository90\Rules;
+
+use Neos\Rector\Core\FusionProcessing\EelExpressionTransformer;
+use Neos\Rector\Core\FusionProcessing\FusionRectorInterface;
+use Neos\Rector\Utility\CodeSampleLoader;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+class FusionNodeNodeTypeRector implements FusionRectorInterface
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return CodeSampleLoader::fromFile('Fusion: Rewrite "node.nodeType" and "q(node).property(\'_nodeType\')" to "Neos.Node.getNodeType(node)"', __CLASS__);
+    }
+
+    public function refactorFileContent(string $fileContent): string
+    {
+        return EelExpressionTransformer::parse($fileContent)
+            ->process(fn(string $eelExpression) => preg_replace(
+                '/(node|documentNode|site)\.nodeType\.name/',
+                'q($1).nodeTypeName()',
+                $eelExpression
+            ))
+            ->process(fn(string $eelExpression) => preg_replace(
+                '/(node|documentNode|site)\.nodeType/',
+                'Neos.Node.getNodeType($1)',
+                $eelExpression
+            ))
+            ->addCommentsIfRegexMatches(
+                '/\.nodeType\b(?!\()/',
+                '// TODO 9.0 migration: Line %LINE: You very likely need to rewrite "VARIABLE.nodeType" to "Neos.Node.getNodeType(VARIABLE)". We did not auto-apply this migration because we cannot be sure whether the variable is a Node.'
+            )
+            ->process(fn(string $eelExpression) => preg_replace(
+                '/\.property\\((\'|")_nodeType.name(\'|")\\)/',
+                '.nodeTypeName()',
+                $eelExpression
+            ))
+            ->process(fn(string $eelExpression) => preg_replace(
+                '/q\(([^)]+)\)\.property\\([\'"]_nodeType(\.[^\'"]*)?[\'"]\\)/',
+                'Neos.Node.getNodeType($1)$2',
+                $eelExpression
+            ))
+            ->getProcessedContent();
+    }
+}

--- a/tests/ContentRepository90/Rules/FusionNodeNodeTypeRector/Fixture/flow_query_property.fusion.inc
+++ b/tests/ContentRepository90/Rules/FusionNodeNodeTypeRector/Fixture/flow_query_property.fusion.inc
@@ -1,0 +1,15 @@
+prototype(Neos.Rector:Test)  < prototype(Neos.Fusion:Value) {
+  node = ${q(node).property('_nodeType') || q(documentNode).property("_nodeType") || q(site).property("_nodeType")}
+  otherVariable = ${q(someOtherVariable).property('_nodeType')}
+  nested = ${q(someOtherVariable).property('_nodeType.properties')}
+  deepNested = ${q(someOtherVariable).property('_nodeType.options.myOption')}
+  inAfx = afx`<Neos.Fusion:Value value={q(node).property('_nodeType')}/>`
+}
+-----
+prototype(Neos.Rector:Test)  < prototype(Neos.Fusion:Value) {
+  node = ${Neos.Node.getNodeType(node) || Neos.Node.getNodeType(documentNode) || Neos.Node.getNodeType(site)}
+  otherVariable = ${Neos.Node.getNodeType(someOtherVariable)}
+  nested = ${Neos.Node.getNodeType(someOtherVariable).properties}
+  deepNested = ${Neos.Node.getNodeType(someOtherVariable).options.myOption}
+  inAfx = afx`<Neos.Fusion:Value value={Neos.Node.getNodeType(node)}/>`
+}

--- a/tests/ContentRepository90/Rules/FusionNodeNodeTypeRector/Fixture/node_getter.fusion.inc
+++ b/tests/ContentRepository90/Rules/FusionNodeNodeTypeRector/Fixture/node_getter.fusion.inc
@@ -1,0 +1,12 @@
+prototype(Neos.Rector:Test)  < prototype(Neos.Fusion:Value) {
+  node = ${node.nodeType || documentNode.nodeType || site.nodeType}
+  otherVariable = ${someOtherVariable.nodeType}
+  inAfx = afx`<Neos.Fusion:Value value={node.nodeType}/>`
+}
+-----
+// TODO 9.0 migration: Line 4: You very likely need to rewrite "VARIABLE.nodeType" to "Neos.Node.getNodeType(VARIABLE)". We did not auto-apply this migration because we cannot be sure whether the variable is a Node.
+prototype(Neos.Rector:Test)  < prototype(Neos.Fusion:Value) {
+  node = ${Neos.Node.getNodeType(node) || Neos.Node.getNodeType(documentNode) || Neos.Node.getNodeType(site)}
+  otherVariable = ${someOtherVariable.nodeType}
+  inAfx = afx`<Neos.Fusion:Value value={Neos.Node.getNodeType(node)}/>`
+}

--- a/tests/ContentRepository90/Rules/FusionNodeNodeTypeRector/Fixture/node_nodeTypeName_flow_query_property.fusion.inc
+++ b/tests/ContentRepository90/Rules/FusionNodeNodeTypeRector/Fixture/node_nodeTypeName_flow_query_property.fusion.inc
@@ -1,0 +1,11 @@
+prototype(Neos.Rector:Test)  < prototype(Neos.Fusion:Value) {
+  node = ${q(node).property('_nodeType.name') || q(documentNode).property("_nodeType.name") || q(site).property("_nodeType.name")}
+  otherVariable = ${q(someOtherVariable).property('_nodeType.name')}
+  inAfx = afx`<Neos.Fusion:Value value={q(node).property('_nodeType.name')}/>`
+}
+-----
+prototype(Neos.Rector:Test)  < prototype(Neos.Fusion:Value) {
+  node = ${q(node).nodeTypeName() || q(documentNode).nodeTypeName() || q(site).nodeTypeName()}
+  otherVariable = ${q(someOtherVariable).nodeTypeName()}
+  inAfx = afx`<Neos.Fusion:Value value={q(node).nodeTypeName()}/>`
+}

--- a/tests/ContentRepository90/Rules/FusionNodeNodeTypeRector/Fixture/node_nodeTypeName_getter.fusion.inc
+++ b/tests/ContentRepository90/Rules/FusionNodeNodeTypeRector/Fixture/node_nodeTypeName_getter.fusion.inc
@@ -1,0 +1,12 @@
+prototype(Neos.Rector:Test)  < prototype(Neos.Fusion:Value) {
+  node = ${node.nodeType.name || documentNode.nodeType.name || site.nodeType.name}
+  otherVariable = ${someOtherVariable.nodeType.name}
+  inAfx = afx`<Neos.Fusion:Value value={node.nodeType.name}/>`
+}
+-----
+// TODO 9.0 migration: Line 4: You very likely need to rewrite "VARIABLE.nodeType" to "Neos.Node.getNodeType(VARIABLE)". We did not auto-apply this migration because we cannot be sure whether the variable is a Node.
+prototype(Neos.Rector:Test)  < prototype(Neos.Fusion:Value) {
+  node = ${q(node).nodeTypeName() || q(documentNode).nodeTypeName() || q(site).nodeTypeName()}
+  otherVariable = ${someOtherVariable.nodeType.name}
+  inAfx = afx`<Neos.Fusion:Value value={q(node).nodeTypeName()}/>`
+}

--- a/tests/ContentRepository90/Rules/FusionNodeNodeTypeRector/FusionNodeNodeTypeRectorTest.php
+++ b/tests/ContentRepository90/Rules/FusionNodeNodeTypeRector/FusionNodeNodeTypeRectorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\Rector\Tests\ContentRepository90\Rules\FusionNodeNodeTypeRector;
+
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class FusionNodeNodeTypeRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(string $fileInfo): void
+    {
+        $this->doTestFile($fileInfo);
+    }
+
+    /**
+     * @return \Iterator<string>
+     */
+    public function provideData(): \Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture', '*.fusion.inc');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/ContentRepository90/Rules/FusionNodeNodeTypeRector/config/configured_rule.php
+++ b/tests/ContentRepository90/Rules/FusionNodeNodeTypeRector/config/configured_rule.php
@@ -1,0 +1,19 @@
+<?php
+
+declare (strict_types=1);
+
+use Neos\Rector\ContentRepository90\Rules\FusionNodeNodeTypeRector;
+use Neos\Rector\Core\FusionProcessing\FusionFileProcessor;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig) : void {
+    $services = $rectorConfig->services();
+    $services->defaults()
+        ->public()
+        ->autowire()
+        ->autoconfigure();
+    $services->set(FusionFileProcessor::class);
+    $rectorConfig->disableParallel(); // does not work for fusion files - see https://github.com/rectorphp/rector-src/pull/2597#issuecomment-1190120688
+
+    $rectorConfig->rule(FusionNodeNodeTypeRector::class);
+};


### PR DESCRIPTION
Solves partially https://github.com/neos/rector/issues/57

Also migrates `q(node).property('_nodeType.name')` as we actually used the syntax once as well: https://github.com/neos/neos-development-collection/pull/3641