### PR TITLE
TASK: Replace usages of `Neos.Neos:PrimaryContent`

### DIFF
--- a/config/set/contentrepository-90.php
+++ b/config/set/contentrepository-90.php
@@ -396,7 +396,7 @@ return static function (RectorConfig $rectorConfig): void {
         new FusionPrototypeNameAddComment('Neos.Fusion:Attributes', 'TODO 9.0 migration: Neos.Fusion:Attributes has been removed without a replacement. You need to replace it by the property attributes in Neos.Fusion:Tag')
     ]);
     $rectorConfig->ruleWithConfiguration(FusionReplacePrototypeNameRector::class, [
-        new FusionPrototypeNameReplacement('Neos.Neos:PrimaryContent', 'Neos.Neos:ContentCollection', 'TODO 9.0 migration: bla bla', true),
+        new FusionPrototypeNameReplacement('Neos.Neos:PrimaryContent', 'Neos.Neos:ContentCollection', '"Neos.Neos:PrimaryContent" has been removed without a complete replacement. We replaced all usages with "Neos.Neos:ContentCollection" but not the prototype definition. Please check the replacements and if you have overridden the "Neos.Neos:PrimaryContent" prototype and rewrite it for your needs.', true),
     ]);
 
 

--- a/config/set/contentrepository-90.php
+++ b/config/set/contentrepository-90.php
@@ -393,9 +393,12 @@ return static function (RectorConfig $rectorConfig): void {
      * Neos.Fusion:Attributes
      */
     $rectorConfig->ruleWithConfiguration(FusionPrototypeNameAddCommentRector::class, [
-        new FusionPrototypeNameAddComment('Neos.Neos:PrimaryContent', 'TODO 9.0 migration: You need to refactor "Neos.Neos:PrimaryContent" to use "Neos.Neos:ContentCollection" instead.'),
         new FusionPrototypeNameAddComment('Neos.Fusion:Attributes', 'TODO 9.0 migration: Neos.Fusion:Attributes has been removed without a replacement. You need to replace it by the property attributes in Neos.Fusion:Tag')
     ]);
+    $rectorConfig->ruleWithConfiguration(FusionReplacePrototypeNameRector::class, [
+        new FusionPrototypeNameReplacement('Neos.Neos:PrimaryContent', 'Neos.Neos:ContentCollection', 'TODO 9.0 migration: bla bla', true),
+    ]);
+
 
     $rectorConfig->rule(ContentRepositoryUtilityRenderValidNodeNameRector::class);
 

--- a/src/Generic/Rules/FusionReplacePrototypeNameRector.php
+++ b/src/Generic/Rules/FusionReplacePrototypeNameRector.php
@@ -28,7 +28,11 @@ class FusionReplacePrototypeNameRector implements FusionRectorInterface, Configu
         $comments = [];
         foreach ($this->fusionPrototypeNameReplacements as $fusionPrototypeNameReplacement) {
             $replacementCount = 0;
-            $pattern = '/(^|[=\s\(<\/])(' .$fusionPrototypeNameReplacement->oldName. ')([\s\{\)\/>]|$)/';
+            if ($fusionPrototypeNameReplacement->skipPrototypeDefinitions) {
+                $pattern = '/(^|[=\s<\/])(' .$fusionPrototypeNameReplacement->oldName. ')([\s{\/>]|$)/';
+            } else {
+                $pattern = '/(^|[=\s(<\/])(' .$fusionPrototypeNameReplacement->oldName. ')([\s{)\/>]|$)/';
+            }
             $replacement = '$1'.$fusionPrototypeNameReplacement->newName.'$3';
             $fileContent = preg_replace($pattern, $replacement, $fileContent, count: $replacementCount);
 

--- a/src/Generic/Rules/FusionReplacePrototypeNameRector.php
+++ b/src/Generic/Rules/FusionReplacePrototypeNameRector.php
@@ -37,7 +37,7 @@ class FusionReplacePrototypeNameRector implements FusionRectorInterface, Configu
             $fileContent = preg_replace($pattern, $replacement, $fileContent, count: $replacementCount);
 
             if($replacementCount > 0 &&  $fusionPrototypeNameReplacement->comment !== null) {
-                $comments[] = '// TODO 9.0 migration:' . $fusionPrototypeNameReplacement->comment;
+                $comments[] = '// TODO 9.0 migration: ' . $fusionPrototypeNameReplacement->comment;
             }
         }
 

--- a/src/Generic/ValueObject/FusionPrototypeNameReplacement.php
+++ b/src/Generic/ValueObject/FusionPrototypeNameReplacement.php
@@ -8,7 +8,8 @@ class FusionPrototypeNameReplacement
     public function __construct(
         public readonly string $oldName,
         public readonly string $newName,
-        public readonly ?string $comment = null
+        public readonly ?string $comment = null,
+        public readonly bool $skipPrototypeDefinitions = false,
     ) {
     }
 }

--- a/tests/Generic/Rules/FusionPrototypeNameReplacement/Fixture/skip_prototype_definition.fusion.inc
+++ b/tests/Generic/Rules/FusionPrototypeNameReplacement/Fixture/skip_prototype_definition.fusion.inc
@@ -6,8 +6,8 @@ prototype(Neos.Neos:Foo) < prototype(Neos.Neos:Bar) {
     `
 }
 -----
-// TODO 9.0 migration: todo
-// TODO 9.0 migration: todo
+// TODO 9.0 migration: Neos.Neos:FooReplaced: This comment should be added on top of the file.
+// TODO 9.0 migration: Neos.Neos:BarReplaced: This comment should be added on top of the file.
 prototype(Neos.Neos:Foo) < prototype(Neos.Neos:Bar) {
 
     raw = Neos.Neos:FooReplaced

--- a/tests/Generic/Rules/FusionPrototypeNameReplacement/Fixture/skip_prototype_definition.fusion.inc
+++ b/tests/Generic/Rules/FusionPrototypeNameReplacement/Fixture/skip_prototype_definition.fusion.inc
@@ -1,0 +1,17 @@
+prototype(Neos.Neos:Foo) < prototype(Neos.Neos:Bar) {
+
+    raw = Neos.Neos:Foo
+    renderer = afx`
+        <Neos.Neos:Bar />
+    `
+}
+-----
+// TODO 9.0 migration:todo
+// TODO 9.0 migration:todo
+prototype(Neos.Neos:Foo) < prototype(Neos.Neos:Bar) {
+
+    raw = Neos.Neos:FooReplaced
+    renderer = afx`
+        <Neos.Neos:BarReplaced />
+    `
+}

--- a/tests/Generic/Rules/FusionPrototypeNameReplacement/Fixture/skip_prototype_definition.fusion.inc
+++ b/tests/Generic/Rules/FusionPrototypeNameReplacement/Fixture/skip_prototype_definition.fusion.inc
@@ -6,8 +6,8 @@ prototype(Neos.Neos:Foo) < prototype(Neos.Neos:Bar) {
     `
 }
 -----
-// TODO 9.0 migration:todo
-// TODO 9.0 migration:todo
+// TODO 9.0 migration: todo
+// TODO 9.0 migration: todo
 prototype(Neos.Neos:Foo) < prototype(Neos.Neos:Bar) {
 
     raw = Neos.Neos:FooReplaced

--- a/tests/Generic/Rules/FusionPrototypeNameReplacement/Fixture/some_file.fusion.inc
+++ b/tests/Generic/Rules/FusionPrototypeNameReplacement/Fixture/some_file.fusion.inc
@@ -16,8 +16,8 @@ prototype(Neos.Neos:SomethingOld)  < prototype(Neos.Neos:Raw) {
     }
 }
 -----
-// TODO 9.0 migration:Neos.Neos:Raw: This comment should be added on top of the file.
-// TODO 9.0 migration:Neos.Neos:SomethingOlder: This comment should be added on top of the file.
+// TODO 9.0 migration: Neos.Neos:Raw: This comment should be added on top of the file.
+// TODO 9.0 migration: Neos.Neos:SomethingOlder: This comment should be added on top of the file.
 prototype(Neos.Neos:SomethingNew)  < prototype(Neos.Neos:NewRaw) {
 
     raw = Neos.Neos:NewRaw

--- a/tests/Generic/Rules/FusionPrototypeNameReplacement/config/configured_rule.php
+++ b/tests/Generic/Rules/FusionPrototypeNameReplacement/config/configured_rule.php
@@ -21,7 +21,7 @@ return static function (RectorConfig $rectorConfig) : void {
         new FusionPrototypeNameReplacement('Neos.Neos:NotExisting', 'Neos.Neos:NewNotExisting', 'Neos.Neos:NotExisting: This comment should NOT be added on top of the file.'),
         new FusionPrototypeNameReplacement('Neos.Neos:SomethingOld', 'Neos.Neos:SomethingNew'),
         new FusionPrototypeNameReplacement('Neos.Neos:SomethingOlder', 'Neos.Neos:SomethingNewer', 'Neos.Neos:SomethingOlder: This comment should be added on top of the file.'),
-        new FusionPrototypeNameReplacement('Neos.Neos:Foo', 'Neos.Neos:FooReplaced', 'todo', true),
-        new FusionPrototypeNameReplacement('Neos.Neos:Bar', 'Neos.Neos:BarReplaced', 'todo', true),
+        new FusionPrototypeNameReplacement('Neos.Neos:Foo', 'Neos.Neos:FooReplaced', 'Neos.Neos:FooReplaced: This comment should be added on top of the file.', true),
+        new FusionPrototypeNameReplacement('Neos.Neos:Bar', 'Neos.Neos:BarReplaced', 'Neos.Neos:BarReplaced: This comment should be added on top of the file.', true),
     ]);
 };

--- a/tests/Generic/Rules/FusionPrototypeNameReplacement/config/configured_rule.php
+++ b/tests/Generic/Rules/FusionPrototypeNameReplacement/config/configured_rule.php
@@ -21,5 +21,7 @@ return static function (RectorConfig $rectorConfig) : void {
         new FusionPrototypeNameReplacement('Neos.Neos:NotExisting', 'Neos.Neos:NewNotExisting', 'Neos.Neos:NotExisting: This comment should NOT be added on top of the file.'),
         new FusionPrototypeNameReplacement('Neos.Neos:SomethingOld', 'Neos.Neos:SomethingNew'),
         new FusionPrototypeNameReplacement('Neos.Neos:SomethingOlder', 'Neos.Neos:SomethingNewer', 'Neos.Neos:SomethingOlder: This comment should be added on top of the file.'),
+        new FusionPrototypeNameReplacement('Neos.Neos:Foo', 'Neos.Neos:FooReplaced', 'todo', true),
+        new FusionPrototypeNameReplacement('Neos.Neos:Bar', 'Neos.Neos:BarReplaced', 'todo', true),
     ]);
 };

--- a/tests/Sets/ContentRepository90/ContentRepository90Test.php
+++ b/tests/Sets/ContentRepository90/ContentRepository90Test.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\Rector\Tests\Sets\ContentRepository90;
+
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class ContentRepository90Test extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(string $fileInfo): void
+    {
+        $this->doTestFile($fileInfo);
+    }
+
+    /**
+     * @return \Iterator<string>
+     */
+    public function provideData(): \Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture', '*.fusion.inc');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/../../../config/set/contentrepository-90.php';
+    }
+}

--- a/tests/Sets/ContentRepository90/Fixture/baseline.fusion.inc
+++ b/tests/Sets/ContentRepository90/Fixture/baseline.fusion.inc
@@ -1,0 +1,22 @@
+prototype(Neos.Neos:PrimaryContent) {
+  myArticle {
+    condition = ${q(node).is('[instanceof My.Site:Article]')}
+    renderer = My.Site:ArticleRenderer
+  }
+}
+
+content = Neos.Neos:PrimaryContent {
+  nodePath = 'main'
+}
+-----
+// TODO 9.0 migration:TODO 9.0 migration: bla bla
+prototype(Neos.Neos:PrimaryContent) {
+  myArticle {
+    condition = ${q(node).is('[instanceof My.Site:Article]')}
+    renderer = My.Site:ArticleRenderer
+  }
+}
+
+content = Neos.Neos:ContentCollection {
+  nodePath = 'main'
+}

--- a/tests/Sets/ContentRepository90/Fixture/primary-content.fusion.inc
+++ b/tests/Sets/ContentRepository90/Fixture/primary-content.fusion.inc
@@ -9,7 +9,7 @@ content = Neos.Neos:PrimaryContent {
   nodePath = 'main'
 }
 -----
-// TODO 9.0 migration:TODO 9.0 migration: bla bla
+// TODO 9.0 migration: "Neos.Neos:PrimaryContent" has been removed without a complete replacement. We replaced all usages with "Neos.Neos:ContentCollection" but not the prototype definition. Please check the replacements and if you have overridden the "Neos.Neos:PrimaryContent" prototype and rewrite it for your needs.
 prototype(Neos.Neos:PrimaryContent) {
   myArticle {
     condition = ${q(node).is('[instanceof My.Site:Article]')}


### PR DESCRIPTION
Adjusts the set such that usages of `Neos.Neos:PrimaryContent` are replaced while overrides are still kept

Resolves: #78
Related: #79