### PR TITLE
BUGFIX: Configure each rule once, as multiple definitions just override the previous ones

### DIFF
--- a/config/set/contentrepository-90.php
+++ b/config/set/contentrepository-90.php
@@ -55,6 +55,7 @@ use Neos\Rector\ContentRepository90\Rules\NodeTypeGetTypeOfAutoCreatedChildNodeR
 use Neos\Rector\ContentRepository90\Rules\WorkspaceGetNameRector;
 use Neos\Rector\ContentRepository90\Rules\WorkspaceRepositoryCountByNameRector;
 use Neos\Rector\ContentRepository90\Rules\YamlDimensionConfigRector;
+use Neos\Rector\Generic\Rules\FusionFlowQueryNodePropertyToWarningCommentRector;
 use Neos\Rector\Generic\Rules\FusionNodePropertyPathToWarningCommentRector;
 use Neos\Rector\Generic\Rules\FusionPrototypeNameAddCommentRector;
 use Neos\Rector\Generic\Rules\FusionReplacePrototypeNameRector;
@@ -119,6 +120,7 @@ return static function (RectorConfig $rectorConfig): void {
         new FusionPrototypeNameReplacement('Neos.Fusion:RawCollection', 'Neos.Fusion:Map',
             'Migration of Neos.Fusion:RawCollection to Neos.Fusion:Map needs manual action. The key `children` has to be renamed to `items` which cannot be done automatically'
         ),
+        new FusionPrototypeNameReplacement('Neos.Neos:PrimaryContent', 'Neos.Neos:ContentCollection', '"Neos.Neos:PrimaryContent" has been removed without a complete replacement. We replaced all usages with "Neos.Neos:ContentCollection" but not the prototype definition. Please check the replacements and if you have overridden the "Neos.Neos:PrimaryContent" prototype and rewrite it for your needs.', true),
     ]);
 
 
@@ -258,7 +260,7 @@ return static function (RectorConfig $rectorConfig): void {
 
     // getOtherNodeVariants()
 
-    $rectorConfig->ruleWithConfiguration(FusionNodePropertyPathToWarningCommentRector::class, $fusionFlowQueryPropertyToComments);
+    $rectorConfig->ruleWithConfiguration(FusionFlowQueryNodePropertyToWarningCommentRector::class, $fusionFlowQueryPropertyToComments);
 
 
     /**
@@ -393,16 +395,11 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->rule(WorkspaceGetNameRector::class);
 
     /**
-     * Neos.Neos:PrimaryContent
      * Neos.Fusion:Attributes
      */
     $rectorConfig->ruleWithConfiguration(FusionPrototypeNameAddCommentRector::class, [
         new FusionPrototypeNameAddComment('Neos.Fusion:Attributes', 'TODO 9.0 migration: Neos.Fusion:Attributes has been removed without a replacement. You need to replace it by the property attributes in Neos.Fusion:Tag')
     ]);
-    $rectorConfig->ruleWithConfiguration(FusionReplacePrototypeNameRector::class, [
-        new FusionPrototypeNameReplacement('Neos.Neos:PrimaryContent', 'Neos.Neos:ContentCollection', '"Neos.Neos:PrimaryContent" has been removed without a complete replacement. We replaced all usages with "Neos.Neos:ContentCollection" but not the prototype definition. Please check the replacements and if you have overridden the "Neos.Neos:PrimaryContent" prototype and rewrite it for your needs.', true),
-    ]);
-
 
     $rectorConfig->rule(ContentRepositoryUtilityRenderValidNodeNameRector::class);
 
@@ -464,7 +461,10 @@ return static function (RectorConfig $rectorConfig): void {
         \Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateIds::class => 'toJson()',
     ]);
 
-    $rectorConfig->ruleWithConfiguration(RenameClassRector::class, [
+    // We can only add one rule per class name. As workaround, we need to alias the RenameClassRector, so we are able to
+    // add this rule twice.
+    class_alias(RenameClassRector::class, \Alias\RenameClassRectorLegacy::class);
+    $rectorConfig->ruleWithConfiguration(\Alias\RenameClassRectorLegacy::class, [
         NodeLegacyStub::class => Node::class,
     ]);
 

--- a/tests/Sets/ContentRepository90/ContentRepository90Test.php
+++ b/tests/Sets/ContentRepository90/ContentRepository90Test.php
@@ -21,7 +21,10 @@ final class ContentRepository90Test extends AbstractRectorTestCase
      */
     public function provideData(): \Iterator
     {
-        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture', '*.fusion.inc');
+        $append = new \AppendIterator();
+        $append->append($this->yieldFilesFromDirectory(__DIR__ . '/Fixture'));
+        $append->append($this->yieldFilesFromDirectory(__DIR__ . '/Fixture', '*.fusion.inc'));
+        return $append;
     }
 
     public function provideConfigFilePath(): string

--- a/tests/Sets/ContentRepository90/Fixture/rename-node-interface-classes.php.inc
+++ b/tests/Sets/ContentRepository90/Fixture/rename-node-interface-classes.php.inc
@@ -1,0 +1,47 @@
+<?php
+
+namespace Neos\Rector\Test;
+
+use Neos\ContentRepository\Domain\Model\NodeInterface;
+use \Neos\ContentRepository\Domain\Model\Node;
+
+class SomeClass extends AnotherClass
+{
+
+    public function foo(Node $node, NodeInterface $targetNode)
+    {
+        /** @var array<Node> $childNodes */
+        $childNodes = $node->getChildNodes();
+
+        $parent = $targetNode->getParent();
+    }
+
+}
+
+-----
+<?php
+
+namespace Neos\Rector\Test;
+
+use Neos\ContentRepository\Domain\Model\NodeInterface;
+use \Neos\ContentRepository\Domain\Model\Node;
+
+class SomeClass extends AnotherClass
+{
+
+    #[\Neos\Flow\Annotations\Inject]
+    protected \Neos\ContentRepositoryRegistry\ContentRepositoryRegistry $contentRepositoryRegistry;
+    public function foo(\Neos\ContentRepository\Core\Projection\ContentGraph\Node $node, \Neos\ContentRepository\Core\Projection\ContentGraph\Node $targetNode)
+    {
+        $subgraph = $this->contentRepositoryRegistry->subgraphForNode($node);
+        // TODO 9.0 migration: Try to remove the iterator_to_array($nodes) call.
+
+        /** @var array<\Neos\ContentRepository\Core\Projection\ContentGraph\Node> $childNodes */
+        $childNodes = iterator_to_array($subgraph->findChildNodes($node->nodeAggregateId, \Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindChildNodesFilter::create()));
+        $subgraph = $this->contentRepositoryRegistry->subgraphForNode($targetNode);
+
+        $parent = $subgraph->findParentNode($targetNode->nodeAggregateId);
+    }
+
+}
+


### PR DESCRIPTION
This fix re-enables the class renaming of e.g. the NodeInterface. 
Also added a testcase ensure this is working.