### PR TITLE
TASK: Improve signal slot handling for PublishingService

### DIFF
--- a/config/set/contentrepository-90.php
+++ b/config/set/contentrepository-90.php
@@ -567,6 +567,11 @@ return static function (RectorConfig $rectorConfig): void {
     $signalsAndSlotsToComment[] = new SignalSlotToWarningComment(\Neos\ContentRepository\Domain\Service\PublishingService::class, 'nodePublished', 'The signal "nodePublished" on "PublishingService" has been removed. Please check https://docs.neos.io/api/upgrade-instructions/9/signals-and-slots for further information, how to replace a signal.');
     // - nodeDiscarded
     $signalsAndSlotsToComment[] = new SignalSlotToWarningComment(\Neos\ContentRepository\Domain\Service\PublishingService::class, 'nodeDiscarded', 'The signal "nodeDiscarded" on "PublishingService" has been removed. Please check https://docs.neos.io/api/upgrade-instructions/9/signals-and-slots for further information, how to replace a signal.');
+    // Neos\Neos\Service\PublishingService
+    // - nodePublished
+    $signalsAndSlotsToComment[] = new SignalSlotToWarningComment(\Neos\Neos\Service\PublishingService::class, 'nodePublished', 'The signal "nodePublished" on "PublishingService" has been removed. Please check https://docs.neos.io/api/upgrade-instructions/9/signals-and-slots for further information, how to replace a signal.');
+    // - nodeDiscarded
+    $signalsAndSlotsToComment[] = new SignalSlotToWarningComment(\Neos\Neos\Service\PublishingService::class, 'nodeDiscarded', 'The signal "nodeDiscarded" on "PublishingService" has been removed. Please check https://docs.neos.io/api/upgrade-instructions/9/signals-and-slots for further information, how to replace a signal.');
     // Neos\ContentRepository\Domain\Service\Context
     // - beforeAdoptNode
     $signalsAndSlotsToComment[] = new SignalSlotToWarningComment(\Neos\ContentRepository\Domain\Service\Context::class, 'beforeAdoptNode', 'The signal "beforeAdoptNode" on "Context" has been removed. Please check https://docs.neos.io/api/upgrade-instructions/9/signals-and-slots for further information, how to replace a signal.');

--- a/src/Generic/Rules/SignalSlotToWarningCommentRector.php
+++ b/src/Generic/Rules/SignalSlotToWarningCommentRector.php
@@ -5,7 +5,6 @@ declare (strict_types=1);
 namespace Neos\Rector\Generic\Rules;
 
 use Neos\Flow\SignalSlot\Dispatcher;
-use Neos\Rector\Generic\ValueObject\MethodCallToWarningComment;
 use Neos\Rector\Generic\ValueObject\SignalSlotToWarningComment;
 use Neos\Rector\Utility\CodeSampleLoader;
 use PhpParser\Node;
@@ -15,7 +14,6 @@ use Rector\Core\Rector\AbstractRector;
 use Rector\PostRector\Collector\NodesToAddCollector;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 use Webmozart\Assert\Assert;
-use Neos\Rector\ContentRepository90\Legacy\NodeLegacyStub;
 
 final class SignalSlotToWarningCommentRector extends AbstractRector implements ConfigurableRectorInterface
 {

--- a/tests/Sets/ContentRepository90/Fixture/Signals/PublishingService.php.inc
+++ b/tests/Sets/ContentRepository90/Fixture/Signals/PublishingService.php.inc
@@ -20,6 +20,9 @@ class Package extends BasePackage
 
         $dispatcher->connect(\Neos\ContentRepository\Domain\Service\PublishingService::class, 'nodePublished', function () { return 'foo'; });
         $dispatcher->connect('Neos\ContentRepository\Domain\Service\PublishingService', 'nodeDiscarded', RouterCachingService::class, 'flushCaches');
+
+        $dispatcher->connect(\Neos\Neos\Service\PublishingService::class, 'nodePublished', function () { return 'foo'; });
+        $dispatcher->connect('Neos\Neos\Service\PublishingService', 'nodeDiscarded', RouterCachingService::class, 'flushCaches');
     }
 }
 -----
@@ -49,5 +52,12 @@ class Package extends BasePackage
         // TODO 9.0 migration: The signal "nodeDiscarded" on "PublishingService" has been removed. Please check https://docs.neos.io/api/upgrade-instructions/9/signals-and-slots for further information, how to replace a signal.
 
         $dispatcher->connect('Neos\ContentRepository\Domain\Service\PublishingService', 'nodeDiscarded', RouterCachingService::class, 'flushCaches');
+        // TODO 9.0 migration: The signal "nodePublished" on "PublishingService" has been removed. Please check https://docs.neos.io/api/upgrade-instructions/9/signals-and-slots for further information, how to replace a signal.
+
+
+        $dispatcher->connect(\Neos\Neos\Service\PublishingService::class, 'nodePublished', function () { return 'foo'; });
+        // TODO 9.0 migration: The signal "nodeDiscarded" on "PublishingService" has been removed. Please check https://docs.neos.io/api/upgrade-instructions/9/signals-and-slots for further information, how to replace a signal.
+
+        $dispatcher->connect('Neos\Neos\Service\PublishingService', 'nodeDiscarded', RouterCachingService::class, 'flushCaches');
     }
 }


### PR DESCRIPTION
Add `Neos\Neos\Service\PublishingService` also to list of removed signals slots.

Usually this should be covered by parent class `Neos\ContentRepository\Domain\Service\PublishingService`. But as these classes doesn't exists anymore in the new code base, rector is not able to determine that.