### PR TITLE
TASK: Update migrations to current state of Neos 9

### DIFF
--- a/src/ContentRepository90/Rules/ContextGetRootNodeRector.php
+++ b/src/ContentRepository90/Rules/ContextGetRootNodeRector.php
@@ -78,11 +78,6 @@ final class ContextGetRootNodeRector extends AbstractRector
     }
 
 
-    private function workspace_currentContentStreamId(): Expr
-    {
-        return $this->nodeFactory->createPropertyFetch('workspace', 'currentContentStreamId');
-    }
-
     private function context_dimensions_fallbackToEmpty(Expr $legacyContextStub)
     {
         return new Node\Expr\BinaryOp\Coalesce(

--- a/src/ContentRepository90/Rules/ContextGetRootNodeRector.php
+++ b/src/ContentRepository90/Rules/ContextGetRootNodeRector.php
@@ -55,9 +55,9 @@ final class ContextGetRootNodeRector extends AbstractRector
                     '!! MEGA DIRTY CODE! Ensure to rewrite this; by getting rid of LegacyContextStub.',
                     self::assign('contentRepository', $this->this_contentRepositoryRegistry_get($this->contentRepositoryId_fromString('default')))
                 ),
-                self::assign('workspace', $this->contentRepository_getWorkspaceFinder_findOneByName($this->workspaceName_fromString($this->context_workspaceName_fallbackToLive($node->var)))),
-                self::assign('rootNodeAggregate', $this->contentRepository_getContentGraph_findRootNodeAggregateByType($this->workspace_currentContentStreamId(), $this->nodeTypeName_fromString('Neos.Neos:Sites'))),
-                self::assign('subgraph', $this->contentRepository_getContentGraph_getSubgraph($this->workspace_currentContentStreamId(), $this->dimensionSpacePoint_fromLegacyDimensionArray($this->context_dimensions_fallbackToEmpty($node->var)), $this->visibilityConstraints($node->var))),
+                self::assign('workspace', $this->contentRepository_findWorkspaceByName($this->workspaceName_fromString($this->context_workspaceName_fallbackToLive($node->var)))),
+                self::assign('rootNodeAggregate', $this->contentRepository_getContentGraph_findRootNodeAggregateByType($this->nodeFactory->createPropertyFetch('workspace', 'workspaceName') , $this->nodeTypeName_fromString('Neos.Neos:Sites'))),
+                self::assign('subgraph', $this->contentRepository_getContentGraph_getSubgraph($this->nodeFactory->createPropertyFetch('workspace', 'workspaceName'), $this->dimensionSpacePoint_fromLegacyDimensionArray($this->context_dimensions_fallbackToEmpty($node->var)), $this->visibilityConstraints($node->var))),
 
             ],
             $node
@@ -96,7 +96,7 @@ final class ContextGetRootNodeRector extends AbstractRector
         return new Node\Expr\Ternary(
             $this->nodeFactory->createPropertyFetch($legacyContextStub, 'invisibleContentShown'),
             $this->nodeFactory->createStaticCall(VisibilityConstraints::class, 'withoutRestrictions'),
-            $this->nodeFactory->createStaticCall(VisibilityConstraints::class, 'frontend'),
+            $this->nodeFactory->createStaticCall(VisibilityConstraints::class, 'default'),
         );
     }
 }

--- a/src/ContentRepository90/Rules/NodeGetContextGetWorkspaceNameRector.php
+++ b/src/ContentRepository90/Rules/NodeGetContextGetWorkspaceNameRector.php
@@ -55,21 +55,7 @@ final class NodeGetContextGetWorkspaceNameRector extends AbstractRector
         }
 
         $nodeVar = $node->var->var;
-        $this->nodesToAddCollector->addNodesBeforeNode(
-            [
-                self::assign(
-                    'contentRepository',
-                    $this->this_contentRepositoryRegistry_get(
-                        $this->node_subgraphIdentity_contentRepositoryId($nodeVar)
-                    )
-                )
-            ],
-            $node
-        );
 
-        $workspace = $this->contentRepository_getWorkspaceFinder_findOneByCurrentContentStreamId(
-            $this->node_subgraphIdentity_contentStreamId($nodeVar)
-        );
-        return $this->nodeFactory->createPropertyFetch($workspace, 'workspaceName');
+        return $this->nodeFactory->createPropertyFetch($nodeVar, 'workspaceName');
     }
 }

--- a/src/ContentRepository90/Rules/NodeGetContextGetWorkspaceRector.php
+++ b/src/ContentRepository90/Rules/NodeGetContextGetWorkspaceRector.php
@@ -61,15 +61,15 @@ final class NodeGetContextGetWorkspaceRector extends AbstractRector
                 self::assign(
                     'contentRepository',
                     $this->this_contentRepositoryRegistry_get(
-                        $this->node_subgraphIdentity_contentRepositoryId($nodeVar)
+                        $this->nodeFactory->createPropertyFetch($nodeVar, 'contentRepositoryId')
                     )
                 )
             ],
             $node
         );
 
-        return $this->contentRepository_getWorkspaceFinder_findOneByCurrentContentStreamId(
-            $this->node_subgraphIdentity_contentStreamId($nodeVar)
+        return $this->contentRepository_findWorkspaceByName(
+            $this->nodeFactory->createPropertyFetch($nodeVar, 'workspaceName')
         );
     }
 }

--- a/src/ContentRepository90/Rules/Traits/ContentRepositoryTrait.php
+++ b/src/ContentRepository90/Rules/Traits/ContentRepositoryTrait.php
@@ -29,22 +29,11 @@ trait ContentRepositoryTrait
         );
     }
 
-    private function contentRepository_getWorkspaceFinder_findOneByCurrentContentStreamId(Expr $contentStreamId): Expr
+    private function contentRepository_findWorkspaceByName(Expr $workspaceName)
     {
         return $this->nodeFactory->createMethodCall(
-            $this->contentRepository_getWorkspaceFinder(),
-            'findOneByCurrentContentStreamId',
-            [
-                $contentStreamId
-            ]
-        );
-    }
-
-    private function contentRepository_getWorkspaceFinder_findOneByName(Expr $workspaceName)
-    {
-        return $this->nodeFactory->createMethodCall(
-            $this->contentRepository_getWorkspaceFinder(),
-            'findOneByName',
+            new Variable('contentRepository'),
+            'findWorkspaceByName',
             [
                 $workspaceName
             ]
@@ -60,37 +49,35 @@ trait ContentRepositoryTrait
         );
     }
 
-    private function contentRepository_getContentGraph_findRootNodeAggregateByType(Expr $contentStreamIdentifier, Expr $nodeTypeName)
+    private function contentRepository_getContentGraph_findRootNodeAggregateByType(Expr $workspaceName, Expr $nodeTypeName)
     {
         return $this->nodeFactory->createMethodCall(
-            $this->contentRepository_getContentGraph(),
+            $this->contentRepository_getContentGraph($workspaceName),
             'findRootNodeAggregateByType',
             [
-                $contentStreamIdentifier,
                 $nodeTypeName
             ]
         );
     }
 
-    private function contentRepository_getContentGraph_getSubgraph(Expr $contentStreamId, Expr $dimensionSpacePoint, Expr $visibilityConstraints)
+    private function contentRepository_getContentGraph_getSubgraph(Expr $workspaceName, Expr $dimensionSpacePoint, Expr $visibilityConstraints)
     {
         return $this->nodeFactory->createMethodCall(
-            $this->contentRepository_getContentGraph(),
+            $this->contentRepository_getContentGraph($workspaceName),
             'getSubgraph',
             [
-                $contentStreamId,
                 $dimensionSpacePoint,
                 $visibilityConstraints
             ]
         );
     }
 
-    private function contentRepository_getContentGraph(): Expr
+    private function contentRepository_getContentGraph(Expr $workspaceName): Expr
     {
         return $this->nodeFactory->createMethodCall(
             new Variable('contentRepository'),
             'getContentGraph',
-            []
+            [$workspaceName]
         );
     }
 

--- a/src/ContentRepository90/Rules/Traits/NodeTrait.php
+++ b/src/ContentRepository90/Rules/Traits/NodeTrait.php
@@ -13,35 +13,6 @@ trait NodeTrait
      */
     protected $nodeFactory;
 
-    private function node_subgraphIdentity(Expr $nodeVariable): Expr
-    {
-        return $this->nodeFactory->createPropertyFetch($nodeVariable, 'subgraphIdentity');
-    }
-
-    private function node_subgraphIdentity_contentRepositoryId(Expr $nodeVariable)
-    {
-        return $this->nodeFactory->createPropertyFetch(
-            $this->node_subgraphIdentity($nodeVariable),
-            'contentRepositoryId'
-        );
-    }
-
-    private function node_subgraphIdentity_contentStreamId(Expr $nodeVariable): Expr
-    {
-        return $this->nodeFactory->createPropertyFetch(
-            $this->node_subgraphIdentity($nodeVariable),
-            'contentStreamId'
-        );
-    }
-
-    private function node_subgraphIdentity_dimensionSpacePoint(Expr $nodeVariable): Expr
-    {
-        return $this->nodeFactory->createPropertyFetch(
-            $this->node_subgraphIdentity($nodeVariable),
-            'dimensionSpacePoint'
-        );
-    }
-
     private function node_nodeAggregateId(Expr $nodeVariable): Expr
     {
         return $this->nodeFactory->createPropertyFetch(

--- a/src/ContentRepository90/Rules/WorkspaceRepositoryCountByNameRector.php
+++ b/src/ContentRepository90/Rules/WorkspaceRepositoryCountByNameRector.php
@@ -60,7 +60,7 @@ final class WorkspaceRepositoryCountByNameRector extends AbstractRector
 
         return new Node\Expr\Ternary(
             new Node\Expr\BinaryOp\NotIdentical(
-                $this->contentRepository_getWorkspaceFinder_findOneByName($this->workspaceName_fromString($node->args[0]->value)),
+                $this->contentRepository_findWorkspaceByName($this->workspaceName_fromString($node->args[0]->value)),
                 new Expr\ConstFetch(new Node\Name('null'))
             ),
             new Node\Scalar\LNumber(1),

--- a/tests/ContentRepository90/Rules/WorkspaceRepositoryCountByNameRector/Fixture/some_class.php.inc
+++ b/tests/ContentRepository90/Rules/WorkspaceRepositoryCountByNameRector/Fixture/some_class.php.inc
@@ -32,7 +32,7 @@ class SomeClass
         $contentRepository = $this->contentRepositoryRegistry->get(\Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId::fromString('default'));
         // TODO 9.0 migration: remove ternary operator (...? 1 : 0 ) - unnecessary complexity
 
-        return $contentRepository->getWorkspaceFinder()->findOneByName(\Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName::fromString($workspace)) !== null ? 1 : 0;
+        return $contentRepository->findWorkspaceByName(\Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName::fromString($workspace)) !== null ? 1 : 0;
     }
 }
 

--- a/tests/Rules/ContextGetRootNodeRector/Fixture/some_class.php.inc
+++ b/tests/Rules/ContextGetRootNodeRector/Fixture/some_class.php.inc
@@ -22,9 +22,9 @@ class SomeClass
     {
         // TODO 9.0 migration: !! MEGA DIRTY CODE! Ensure to rewrite this; by getting rid of LegacyContextStub.
         $contentRepository = $this->contentRepositoryRegistry->get(\Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId::fromString('default'));
-        $workspace = $contentRepository->getWorkspaceFinder()->findOneByName(\Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName::fromString($context->workspaceName ?? 'live'));
-        $rootNodeAggregate = $contentRepository->getContentGraph()->findRootNodeAggregateByType($workspace->currentContentStreamId, \Neos\ContentRepository\Core\NodeType\NodeTypeName::fromString('Neos.Neos:Sites'));
-        $subgraph = $contentRepository->getContentGraph()->getSubgraph($workspace->currentContentStreamId, \Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePoint::fromLegacyDimensionArray($context->dimensions ?? []), $context->invisibleContentShown ? \Neos\ContentRepository\Core\Projection\ContentGraph\VisibilityConstraints::withoutRestrictions() : \Neos\ContentRepository\Core\Projection\ContentGraph\VisibilityConstraints::frontend());
+        $workspace = $contentRepository->findWorkspaceByName(\Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName::fromString($context->workspaceName ?? 'live'));
+        $rootNodeAggregate = $contentRepository->getContentGraph($workspace->workspaceName)->findRootNodeAggregateByType(\Neos\ContentRepository\Core\NodeType\NodeTypeName::fromString('Neos.Neos:Sites'));
+        $subgraph = $contentRepository->getContentGraph($workspace->workspaceName)->getSubgraph(\Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePoint::fromLegacyDimensionArray($context->dimensions ?? []), $context->invisibleContentShown ? \Neos\ContentRepository\Core\Projection\ContentGraph\VisibilityConstraints::withoutRestrictions() : \Neos\ContentRepository\Core\Projection\ContentGraph\VisibilityConstraints::default());
         return $subgraph->findNodeById($rootNodeAggregate->nodeAggregateId);
     }
 }

--- a/tests/Rules/NodeGetContextGetWorkspaceNameRector/Fixture/some_class.php.inc
+++ b/tests/Rules/NodeGetContextGetWorkspaceNameRector/Fixture/some_class.php.inc
@@ -20,8 +20,7 @@ class SomeClass
 {
     public function run(NodeLegacyStub $node)
     {
-        $contentRepository = $this->contentRepositoryRegistry->get($node->subgraphIdentity->contentRepositoryId);
-        return $contentRepository->getWorkspaceFinder()->findOneByCurrentContentStreamId($node->subgraphIdentity->contentStreamId)->workspaceName;
+        return $node->workspaceName;
     }
 }
 

--- a/tests/Rules/NodeGetContextGetWorkspaceRector/Fixture/some_class.php.inc
+++ b/tests/Rules/NodeGetContextGetWorkspaceRector/Fixture/some_class.php.inc
@@ -20,8 +20,8 @@ class SomeClass
 {
     public function run(NodeLegacyStub $node)
     {
-        $contentRepository = $this->contentRepositoryRegistry->get($node->subgraphIdentity->contentRepositoryId);
-        return $contentRepository->getWorkspaceFinder()->findOneByCurrentContentStreamId($node->subgraphIdentity->contentStreamId);
+        $contentRepository = $this->contentRepositoryRegistry->get($node->contentRepositoryId);
+        return $contentRepository->findWorkspaceByName($node->workspaceName);
     }
 }
 


### PR DESCRIPTION
This PR updates some older migrations to the current state of Neos 9. 
* Removed `Node->subgraphIdentity`
* Removed `contentStreamId` based access to nodes
* Removed `WorkspaceFinder`
* Added usage of new `Node` properties (contentRepositoryId, workspaceName, ...?
* Updated visibility constraints `frontend` => `default`

Fixes: #129 #130 