### PR TITLE
TASK: Refactor SubtreeTag references to NeosSubtreeTag.

### DIFF
--- a/docs/rules_overview.md
+++ b/docs/rules_overview.md
@@ -1758,7 +1758,7 @@ return static function (RectorConfig $rectorConfig): void {
      public function run(NodeLegacyStub $node)
      {
 -        return $node->isHidden();
-+        return $node->tags->contain(\Neos\ContentRepository\Core\Feature\SubtreeTagging\Dto\SubtreeTag::disabled());
++        return $node->tags->contain(\Neos\Neos\Domain\SubtreeTagging\NeosSubtreeTag::disabled());
      }
  }
 

--- a/src/ContentRepository90/Rules/NodeIsHiddenRector.php
+++ b/src/ContentRepository90/Rules/NodeIsHiddenRector.php
@@ -52,7 +52,7 @@ final class NodeIsHiddenRector extends AbstractRector
                 'tags'
             ),
             'contain',
-            [$this->nodeFactory->createStaticCall(\Neos\ContentRepository\Core\Feature\SubtreeTagging\Dto\SubtreeTag::class, 'disabled')]
+            [$this->nodeFactory->createStaticCall(\Neos\Neos\Domain\SubtreeTagging\NeosSubtreeTag::class, 'disabled')]
         );
     }
 }

--- a/tests/Rules/NodeIsHiddenRector/Fixture/some_class.php.inc
+++ b/tests/Rules/NodeIsHiddenRector/Fixture/some_class.php.inc
@@ -20,7 +20,7 @@ class SomeClass
 {
     public function run(NodeLegacyStub $node)
     {
-        return $node->tags->contain(\Neos\ContentRepository\Core\Feature\SubtreeTagging\Dto\SubtreeTag::disabled());
+        return $node->tags->contain(\Neos\Neos\Domain\SubtreeTagging\NeosSubtreeTag::disabled());
     }
 }
 

--- a/tests/Sets/ContentRepository90/Fixture/Node/node-hidden.php.inc
+++ b/tests/Sets/ContentRepository90/Fixture/Node/node-hidden.php.inc
@@ -26,7 +26,7 @@ class SomeClass extends AnotherClass
 {
     public function node(\Neos\ContentRepository\Core\Projection\ContentGraph\Node $node)
     {
-        $hidden = $node->tags->contain(\Neos\ContentRepository\Core\Feature\SubtreeTagging\Dto\SubtreeTag::disabled());
+        $hidden = $node->tags->contain(\Neos\Neos\Domain\SubtreeTagging\NeosSubtreeTag::disabled());
         // TODO 9.0 migration: !! Node::setHidden() is not supported by the new CR. Use the "EnableNodeAggregate" or "DisableNodeAggregate" command to change the visibility of the node.
 
 


### PR DESCRIPTION
As `SubtreeTag::disabled()` is deprecated, we should directly refactor to `NeosSubtreeTag::disabled()`